### PR TITLE
Add project sharing/permissions system for admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# scripts
+/scripts

--- a/src/app/context.tsx
+++ b/src/app/context.tsx
@@ -51,7 +51,7 @@ interface ScriptContextProps {
 type UserConfig = {
   stopOnCharacter: boolean;
   autoAdvanceScript: boolean;
-  dataSource: "local" | "firestore" | "public";
+  dataSource: "local" | "firestore" | "public" | "shared";
 };
 
 // Create the context with default values

--- a/src/components/AdminSharingPanel.tsx
+++ b/src/components/AdminSharingPanel.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "~/trpc/react";
+import { Button } from "./ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
+import { Label } from "./ui/label";
+import { FiTrash2, FiUserPlus, FiRefreshCw, FiShare2 } from "react-icons/fi";
+
+export function AdminSharingPanel() {
+  const [selectedProject, setSelectedProject] = useState<string>("");
+  const [newUserEmail, setNewUserEmail] = useState<string>("");
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  // Fetch admin's Firestore projects
+  const { data: adminProjects } = api.scriptData.getAll.useQuery(
+    { dataSource: "firestore" },
+    {
+      refetchOnWindowFocus: false,
+    },
+  );
+
+  // Fetch all shared projects
+  const {
+    data: sharedProjects,
+    refetch: refetchSharedProjects,
+  } = api.scriptData.getAllSharedProjects.useQuery(undefined, {
+    refetchOnWindowFocus: false,
+  });
+
+  // Mutations
+  const shareProject = api.scriptData.shareExistingProject.useMutation({
+    onSuccess: () => {
+      void refetchSharedProjects();
+      setSelectedProject("");
+    },
+  });
+
+  const updatePermissions = api.scriptData.updateSharedProjectPermissions.useMutation({
+    onSuccess: () => {
+      void refetchSharedProjects();
+    },
+  });
+
+  const syncProject = api.scriptData.syncSharedProject.useMutation({
+    onSuccess: () => {
+      void refetchSharedProjects();
+    },
+  });
+
+  const deleteProject = api.scriptData.deleteSharedProject.useMutation({
+    onSuccess: () => {
+      void refetchSharedProjects();
+      setSelectedProject("");
+    },
+  });
+
+  // Find if selected project is already shared
+  const selectedSharedProject = sharedProjects?.find(
+    (sp) => sp.project === selectedProject,
+  );
+
+  const handleShareProject = async (): Promise<void> => {
+    if (!selectedProject) return;
+    setIsLoading(true);
+    try {
+      await shareProject.mutateAsync({
+        projectName: selectedProject,
+        allowedUsers: [],
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleAddUser = async (): Promise<void> => {
+    if (!selectedSharedProject?.id || !newUserEmail.trim()) return;
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(newUserEmail.trim())) {
+      alert("Please enter a valid email address");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const updatedUsers = [...selectedSharedProject.allowedUsers, newUserEmail.trim()];
+      await updatePermissions.mutateAsync({
+        projectId: selectedSharedProject.id,
+        allowedUsers: updatedUsers,
+      });
+      setNewUserEmail("");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleRemoveUser = async (emailToRemove: string): Promise<void> => {
+    if (!selectedSharedProject?.id) return;
+    setIsLoading(true);
+    try {
+      const updatedUsers = selectedSharedProject.allowedUsers.filter(
+        (email: string) => email !== emailToRemove,
+      );
+      await updatePermissions.mutateAsync({
+        projectId: selectedSharedProject.id,
+        allowedUsers: updatedUsers,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSyncProject = async (): Promise<void> => {
+    if (!selectedSharedProject?.id || !selectedProject) return;
+    setIsLoading(true);
+    try {
+      await syncProject.mutateAsync({
+        sharedProjectId: selectedSharedProject.id,
+        sourceProjectName: selectedProject,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleDeleteProject = async (): Promise<void> => {
+    if (!selectedSharedProject?.id) return;
+    if (!confirm(`Are you sure you want to stop sharing "${selectedProject}"?`)) {
+      return;
+    }
+    setIsLoading(true);
+    try {
+      await deleteProject.mutateAsync({
+        projectId: selectedSharedProject.id,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const projectsList = adminProjects?.projects ?? [];
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Project Selection */}
+      <div>
+        <Label className="text-xs text-stone-600 dark:text-stone-400">
+          Select Project
+        </Label>
+        <Select value={selectedProject} onValueChange={setSelectedProject}>
+          <SelectTrigger className="mt-1">
+            <SelectValue placeholder="Choose a project..." />
+          </SelectTrigger>
+          <SelectContent>
+            {projectsList.map((project) => {
+              const isShared = sharedProjects?.some((sp) => sp.project === project);
+              return (
+                <SelectItem key={project} value={project}>
+                  {isShared ? `🔗 ${project}` : project}
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Actions based on selected project */}
+      {selectedProject && (
+        <div className="flex flex-col gap-2">
+          {selectedSharedProject ? (
+            <>
+              {/* Already shared - show management options */}
+              <div className="rounded-md bg-emerald-50 p-2 text-xs text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400">
+                Shared with {selectedSharedProject.allowedUsers.length} user(s)
+              </div>
+
+              {/* Permitted Users List */}
+              {selectedSharedProject.allowedUsers.length > 0 && (
+                <div className="flex flex-col gap-1">
+                  <Label className="text-xs text-stone-600 dark:text-stone-400">
+                    Permitted Users
+                  </Label>
+                  <div className="max-h-24 overflow-y-auto rounded-md border border-stone-200 dark:border-stone-700">
+                    {selectedSharedProject.allowedUsers.map((email) => (
+                      <div
+                        key={email}
+                        className="flex items-center justify-between border-b border-stone-100 px-2 py-1 last:border-b-0 dark:border-stone-800"
+                      >
+                        <span className="truncate text-xs text-stone-700 dark:text-stone-300">
+                          {email}
+                        </span>
+                        <button
+                          onClick={() => handleRemoveUser(email)}
+                          disabled={isLoading}
+                          className="ml-2 text-red-500 hover:text-red-700 disabled:opacity-50"
+                          title="Remove user"
+                        >
+                          <FiTrash2 className="h-3 w-3" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Add User Form */}
+              <div className="flex gap-1">
+                <input
+                  type="email"
+                  value={newUserEmail}
+                  onChange={(e) => setNewUserEmail(e.target.value)}
+                  placeholder="user@email.com"
+                  className="flex-1 rounded-md border border-stone-300 bg-white px-2 py-1 text-xs text-stone-900 placeholder:text-stone-400 focus:border-stone-500 focus:outline-none dark:border-stone-600 dark:bg-stone-800 dark:text-stone-100"
+                />
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleAddUser}
+                  disabled={isLoading || !newUserEmail.trim()}
+                  className="px-2"
+                >
+                  <FiUserPlus className="h-4 w-4" />
+                </Button>
+              </div>
+
+              {/* Sync and Delete buttons */}
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleSyncProject}
+                  disabled={isLoading}
+                  className="flex-1 text-xs"
+                  title="Sync shared project with your latest changes"
+                >
+                  <FiRefreshCw className={`mr-1 h-3 w-3 ${isLoading ? "animate-spin" : ""}`} />
+                  Sync
+                </Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={handleDeleteProject}
+                  disabled={isLoading}
+                  className="text-xs"
+                  title="Stop sharing this project"
+                >
+                  <FiTrash2 className="h-3 w-3" />
+                </Button>
+              </div>
+            </>
+          ) : (
+            /* Not shared yet - show share button */
+            <Button
+              size="sm"
+              onClick={handleShareProject}
+              disabled={isLoading}
+              className="w-full"
+            >
+              <FiShare2 className="mr-2 h-4 w-4" />
+              Share Project
+            </Button>
+          )}
+        </div>
+      )}
+
+      {/* Summary of all shared projects */}
+      {sharedProjects && sharedProjects.length > 0 && (
+        <div className="mt-2 border-t border-stone-200 pt-2 dark:border-stone-700">
+          <Label className="text-xs text-stone-600 dark:text-stone-400">
+            All Shared Projects ({sharedProjects.length})
+          </Label>
+          <div className="mt-1 flex flex-wrap gap-1">
+            {sharedProjects.map((sp) => (
+              <span
+                key={sp.id}
+                className="rounded-full bg-stone-100 px-2 py-0.5 text-xs text-stone-600 dark:bg-stone-800 dark:text-stone-400"
+              >
+                {sp.project}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/NewScriptSelect.tsx
+++ b/src/components/NewScriptSelect.tsx
@@ -100,9 +100,10 @@ export default function NewScriptSelect({
         (project) => project.project === selectedProject,
       );
       // Extract unique characters from all lines across all scenes
-      const characters = project?.scenes.flatMap((scene) =>
-        scene.lines.flatMap((line) => line.characters)
-      ) ?? [];
+      const characters =
+        project?.scenes
+          .flatMap((scene) => scene.lines.flatMap((line) => line.characters))
+          .sort((a, b) => a.localeCompare(b)) ?? [];
       return Array.from(new Set(characters));
     }
 
@@ -112,9 +113,10 @@ export default function NewScriptSelect({
         (project) => project.project === selectedProject,
       );
       // Extract unique characters from all lines across all scenes
-      const characters = project?.scenes.flatMap((scene) =>
-        scene.lines.flatMap((line) => line.characters)
-      ) ?? [];
+      const characters =
+        project?.scenes
+          .flatMap((scene) => scene.lines.flatMap((line) => line.characters))
+          .sort((a, b) => a.localeCompare(b)) ?? [];
       return Array.from(new Set(characters));
     }
 
@@ -124,9 +126,10 @@ export default function NewScriptSelect({
         (project) => project.project === selectedProject,
       );
       // Extract unique characters from all lines across all scenes
-      const characters = project?.scenes.flatMap((scene) =>
-        scene.lines.flatMap((line) => line.characters)
-      ) ?? [];
+      const characters =
+        project?.scenes
+          .flatMap((scene) => scene.lines.flatMap((line) => line.characters))
+          .sort((a, b) => a.localeCompare(b)) ?? [];
       return Array.from(new Set(characters));
     }
 
@@ -142,9 +145,15 @@ export default function NewScriptSelect({
       const project = publicAllData.find(
         (project) => project.project === selectedProject,
       );
-      return project?.scenes.filter(scene =>
-        scene.lines.some(line => line.characters.includes(selectedCharacter))
-      ).sort((a, b) => a.title.localeCompare(b.title)) ?? [];
+      return (
+        project?.scenes
+          .filter((scene) =>
+            scene.lines.some((line) =>
+              line.characters.includes(selectedCharacter),
+            ),
+          )
+          .sort((a, b) => a.title.localeCompare(b.title)) ?? []
+      );
     }
 
     // Check if it's a shared project
@@ -152,9 +161,15 @@ export default function NewScriptSelect({
       const project = sharedAllData.find(
         (project) => project.project === selectedProject,
       );
-      return project?.scenes.filter(scene =>
-        scene.lines.some(line => line.characters.includes(selectedCharacter))
-      ).sort((a, b) => a.title.localeCompare(b.title)) ?? [];
+      return (
+        project?.scenes
+          .filter((scene) =>
+            scene.lines.some((line) =>
+              line.characters.includes(selectedCharacter),
+            ),
+          )
+          .sort((a, b) => a.title.localeCompare(b.title)) ?? []
+      );
     }
 
     // Check if it's a user project
@@ -162,9 +177,15 @@ export default function NewScriptSelect({
       const project = userAllData.find(
         (project) => project.project === selectedProject,
       );
-      return project?.scenes.filter(scene =>
-        scene.lines.some(line => line.characters.includes(selectedCharacter))
-      ).sort((a, b) => a.title.localeCompare(b.title)) ?? [];
+      return (
+        project?.scenes
+          .filter((scene) =>
+            scene.lines.some((line) =>
+              line.characters.includes(selectedCharacter),
+            ),
+          )
+          .sort((a, b) => a.title.localeCompare(b.title)) ?? []
+      );
     }
 
     return [];
@@ -196,7 +217,6 @@ export default function NewScriptSelect({
     router.push(newQPs);
   };
 
-
   useEffect(() => {
     if (project) {
       setSelectedProject(project.toString());
@@ -222,7 +242,9 @@ export default function NewScriptSelect({
       <Select onValueChange={handleProjectChange} value={selectedProject}>
         <Label>Project</Label>
         <SelectTrigger>
-          <SelectValue placeholder="Select Project">{selectedProject}</SelectValue>
+          <SelectValue placeholder="Select Project">
+            {selectedProject}
+          </SelectValue>
         </SelectTrigger>
         <SelectContent>
           {hierarchicalProjects.map((project, index) => (
@@ -239,14 +261,16 @@ export default function NewScriptSelect({
 
       {/* Character Selection - only show if project is selected */}
       {selectedProject && (
-        <Select 
-          onValueChange={handleCharacterChange} 
+        <Select
+          onValueChange={handleCharacterChange}
           value={selectedCharacter}
           disabled={!selectedProject}
         >
           <Label>Character</Label>
           <SelectTrigger>
-            <SelectValue placeholder="Select Character">{selectedCharacter}</SelectValue>
+            <SelectValue placeholder="Select Character">
+              {selectedCharacter}
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             {characterList?.map((char, index) => (
@@ -260,14 +284,16 @@ export default function NewScriptSelect({
 
       {/* Scene Selection - only show if character is selected */}
       {selectedProject && selectedCharacter && (
-        <Select 
-          onValueChange={handleSceneChange} 
+        <Select
+          onValueChange={handleSceneChange}
           value={selectedScene}
           disabled={!selectedCharacter}
         >
           <Label>Scene</Label>
           <SelectTrigger>
-            <SelectValue placeholder="Select Scene">{selectedScene}</SelectValue>
+            <SelectValue placeholder="Select Scene">
+              {selectedScene}
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             {sceneList?.map((scene, index) => (

--- a/src/components/SidebarClient.tsx
+++ b/src/components/SidebarClient.tsx
@@ -10,6 +10,7 @@ import { Label } from "./ui/label";
 import { RefreshButton } from "./ui/refresh-button";
 import { useScriptData } from "~/hooks/useScriptData";
 import { ThemeToggle } from "./ui/theme-toggle";
+import { AdminSharingPanel } from "./AdminSharingPanel";
 import Link from "next/link";
 
 type SidebarClientProps = {
@@ -171,6 +172,16 @@ export function SidebarClient({
                 )}
               </div>
             </div>
+
+            {/* Project Sharing - Admin Only */}
+            {isAdmin && (
+              <div className="mt-4 border-t border-stone-200 px-2 pt-4 dark:border-stone-700">
+                <p className="mb-2 text-mobile-base font-bold text-stone-900 dark:text-stone-100 iphone:text-base">
+                  Project Sharing
+                </p>
+                <AdminSharingPanel />
+              </div>
+            )}
 
             <div className="mt-2 flex flex-col p-2">
               {/* add a toggle for the "Auto Advance" feature -- when TRUE set the context.autoAdvance to TRUE */}

--- a/src/hooks/useScriptData.ts
+++ b/src/hooks/useScriptData.ts
@@ -3,7 +3,7 @@ import { api } from "~/trpc/react";
 import { useSession } from "next-auth/react";
 
 interface UseScriptDataOptions {
-  dataSource: "local" | "firestore" | "public";
+  dataSource: "local" | "firestore" | "public" | "shared";
   enableAutoRefresh?: boolean;
   cacheTime?: number; // in milliseconds
 }
@@ -21,7 +21,7 @@ export function useScriptData({
   const shouldEnableQuery =
     dataSource === "local" ||
     dataSource === "public" ||
-    (dataSource === "firestore" && !!session?.user?.email);
+    ((dataSource === "firestore" || dataSource === "shared") && !!session?.user?.email);
 
   // Main data query with optimized caching
   const {

--- a/src/server/firebase.ts
+++ b/src/server/firebase.ts
@@ -424,8 +424,8 @@ export class FirestoreService {
         .get();
 
       return querySnapshot.docs.map((doc) => ({
-        id: doc.id,
         ...doc.data(),
+        id: doc.id, // Ensure Firestore doc ID takes precedence
       })) as SharedProjectJSON[];
     } catch (error) {
       console.error("Error getting shared projects for user:", error);
@@ -439,8 +439,8 @@ export class FirestoreService {
       const querySnapshot = await adminDb.collection("shared_projects").get();
 
       return querySnapshot.docs.map((doc) => ({
-        id: doc.id,
         ...doc.data(),
+        id: doc.id, // Ensure Firestore doc ID takes precedence
       })) as SharedProjectJSON[];
     } catch (error) {
       console.error("Error getting all shared projects:", error);
@@ -457,7 +457,7 @@ export class FirestoreService {
       const docSnap = await docRef.get();
 
       if (docSnap.exists) {
-        return { id: docSnap.id, ...docSnap.data() } as SharedProjectJSON;
+        return { ...docSnap.data(), id: docSnap.id } as SharedProjectJSON; // Ensure Firestore doc ID takes precedence
       }
       return null;
     } catch (error) {
@@ -473,8 +473,11 @@ export class FirestoreService {
     ownerId: string,
   ): Promise<string> {
     try {
+      // Destructure to remove any existing 'id' field from the source project
+      const { id: _existingId, ...projectDataWithoutId } = projectData as ProjectJSON & { id?: string };
+
       const sharedProject = {
-        ...projectData,
+        ...projectDataWithoutId,
         ownerId,
         allowedUsers,
         createdAt: FieldValue.serverTimestamp(),


### PR DESCRIPTION
## Summary
Adds an admin-only feature to share projects with other users via email. Shared projects are stored in a dedicated Firestore collection (`shared_projects`) and users with access see them with a 🔗 icon in the project selector.

- Add `shared_projects` Firestore collection with CRUD operations
- Add admin UI panel in sidebar for managing project sharing
- Users granted access see shared projects as read-only
- Admin can sync shared projects when source is updated
- Add "shared" data source throughout the stack (context, hooks, tRPC, services)

## Test plan
- [x] Log in as admin and share a project via the new "Project Sharing" panel
- [x] Add a user email to grant access
- [x] Log in as the granted user and verify the shared project appears with 🔗 icon
- [x] Verify shared project is read-only for non-admin users

🤖 Generated with [Claude Code](https://claude.com/claude-code)