### PR TITLE
feat: Prompt Book UI redesign + project-selection crash fix

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,26 @@
 import "~/styles/globals.css";
 
 import { GeistSans } from "geist/font/sans";
+import { Fraunces, Courier_Prime } from "next/font/google";
 import { TRPCReactProvider } from "~/trpc/react";
 import { Toaster } from "../components/ui/toaster";
 import { Providers } from "~/components/Providers";
 import { Suspense } from "react";
+
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  style: ["normal", "italic"],
+  axes: ["opsz", "SOFT", "WONK"],
+  variable: "--font-fraunces",
+});
+
+const courierPrime = Courier_Prime({
+  subsets: ["latin"],
+  weight: ["400", "700"],
+  style: ["normal", "italic"],
+  variable: "--font-courier-prime",
+});
+
 export const metadata = {
   title: "LineRunner",
   description: "LineRunner",
@@ -17,8 +33,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className={`${GeistSans.variable}`}>
-      <body>
+    <html
+      lang="en"
+      className={`${GeistSans.variable} ${fraunces.variable} ${courierPrime.variable}`}
+    >
+      <body className="font-sans">
         <Suspense fallback={<div>Loading...</div>}>
           <Providers>
             <TRPCReactProvider>{children}</TRPCReactProvider>

--- a/src/components/AppContent.tsx
+++ b/src/components/AppContent.tsx
@@ -40,7 +40,7 @@ export function AppContent({ projectData, sidebarData }: AppContentProps) {
       </div>
 
       {/* Main Content */}
-      <div className="pt-safe-top pb-safe-bottom flex min-h-[100dvh] flex-col items-center justify-center bg-[hsl(var(--background))] p-2 text-[hsl(var(--foreground))] transition-colors [touch-action:manipulation] supports-[height:100svh]:min-h-[100svh]">
+      <div className="pt-safe-top pb-safe-bottom flex min-h-[100dvh] flex-col items-center justify-center p-2 text-foreground transition-colors [touch-action:manipulation] supports-[height:100svh]:min-h-[100svh]">
         <Tabs
           defaultValue="runner"
           className="flex w-full flex-1 flex-col items-center justify-center"

--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -32,7 +32,7 @@ export default function ControlBar({
   handleWordNavigation,
 }: ControlBarProps) {
   return (
-    <div className="flex h-full w-full items-center justify-between gap-2 rounded-b-md  border-stone-200 bg-stone-100/85 px-3 py-1 shadow-lg dark:border-stone-700 dark:bg-stone-800 xs:gap-4 xs:px-1 xs:py-1 sm:px-6">
+    <div className="flex h-full w-full items-center justify-between gap-2 border-t border-border bg-surface-raised/90 px-3 py-1 backdrop-blur-sm xs:gap-4 xs:px-1 xs:py-1 sm:px-6">
       {/* Playback Controls */}
       <div className="flex h-full items-center gap-1">
         <ControlButton

--- a/src/components/NewScriptSelect.tsx
+++ b/src/components/NewScriptSelect.tsx
@@ -190,20 +190,27 @@ export default function NewScriptSelect({
       const sourceParam = queryParams.source as ProjectSource | undefined;
 
       // If source is provided in URL, use it directly
+      let resolvedSource: ProjectSource;
       if (sourceParam && ["public", "shared", "user"].includes(sourceParam)) {
-        setSelectedProject({ name: projectName, source: sourceParam });
+        resolvedSource = sourceParam;
       } else {
         // Legacy URL support: infer source by checking which list contains the project
-        let inferredSource: ProjectSource = "public";
+        resolvedSource = "public";
         if (publicProjects.includes(projectName)) {
-          inferredSource = "public";
+          resolvedSource = "public";
         } else if (sharedProjects.includes(projectName)) {
-          inferredSource = "shared";
+          resolvedSource = "shared";
         } else if (userProjects.includes(projectName)) {
-          inferredSource = "user";
+          resolvedSource = "user";
         }
-        setSelectedProject({ name: projectName, source: inferredSource });
       }
+      // Bail out with the previous object when nothing changed — this effect
+      // re-runs on every render, and a fresh object here loops it forever
+      setSelectedProject((prev) =>
+        prev?.name === projectName && prev.source === resolvedSource
+          ? prev
+          : { name: projectName, source: resolvedSource },
+      );
 
       if (character) {
         setSelectedCharacter(character.toString());

--- a/src/components/ScriptDisplay/CharacterLineDisplay.tsx
+++ b/src/components/ScriptDisplay/CharacterLineDisplay.tsx
@@ -108,25 +108,33 @@ export const CharacterLineDisplay = ({
   };
 
   return (
-    <div style={{ fontSize: `${displayPreferences.fontSize}%` }}>
+    <div
+      className="mx-auto max-w-3xl py-3"
+      style={{ fontSize: `${displayPreferences.fontSize}%` }}
+    >
       {/* revealed lines */}
       {script?.lines.slice(0, currentLineIndex).map((line, index) => {
         const sameAsPrev = isSameCharactersAsPrev(index);
         const isMulti = isMultiCharacter(line.characters);
         return (
-          <li key={index} className="flex flex-col justify-center gap-2 p-2">
+          <li
+            key={index}
+            className="flex flex-col justify-center gap-2 px-3 py-2 opacity-75 transition-opacity hover:opacity-100"
+          >
             <div
-              className={`flex flex-col ${getAlignmentClass(line.characters)} ${isMulti ? multiCharacterContainerStyling : ""}`}
+              className={`flex flex-col gap-0.5 ${getAlignmentClass(line.characters)} ${isMulti ? multiCharacterContainerStyling : ""}`}
             >
               {!sameAsPrev && (
                 <p
-                  className={`text-[1.25em] font-bold ${getNameColorClass(line.characters)}`}
+                  className={`font-sans text-[0.8em] font-bold uppercase tracking-[0.2em] ${getNameColorClass(line.characters) || "text-muted-foreground"}`}
                 >
                   {formatCharacters(line.characters)}
                 </p>
               )}
               {/* sung & spoken lines have different styling */}
-              <p className={`text-[1.25em] ${getLineColorClass(line.characters)}`}>
+              <p
+                className={`font-script text-[1.2em] leading-relaxed ${line.sung ? "italic" : ""} ${getLineColorClass(line.characters)}`}
+              >
                 {line.sung ? line.line.toUpperCase() : line.line}
               </p>
             </div>
@@ -143,24 +151,37 @@ export const CharacterLineDisplay = ({
             .split(" ")
             .slice(0, wordDisplayIndex)
             .join(" ") ?? "";
+          const isConcealed = lineText === "" && currentChars.length > 0;
           return (
-            <li className="flex flex-col justify-center gap-2 p-2">
+            <li className="flex flex-col justify-center gap-2 px-1 py-1">
               <div
-                className={`flex flex-col ${currentChars.length > 0 ? getAlignmentClass(currentChars) : ""} ${isMulti ? multiCharacterContainerStyling : ""}`}
+                className={`flex flex-col gap-0.5 rounded-xl bg-accent/[0.07] px-2 py-2 ring-1 ring-accent/20 ${currentChars.length > 0 ? getAlignmentClass(currentChars) : ""} ${isMulti ? multiCharacterContainerStyling : ""}`}
               >
                 {/* only show char name if diff characters in current line */}
                 {!isSameCharactersAsPrev(currentLineIndex) &&
                   currentChars.length > 0 && (
                     <p
-                      className={`text-[1.25em] font-bold ${getNameColorClass(currentChars)}`}
+                      className={`font-sans text-[0.8em] font-bold uppercase tracking-[0.2em] ${getNameColorClass(currentChars) || "text-muted-foreground"}`}
                     >
                       {formatCharacters(currentChars)}
                     </p>
                   )}
-                {/* line text with appropriate color */}
-                <p className={`text-[1.25em] ${getLineColorClass(currentChars)}`}>
-                  {isSung ? lineText.toUpperCase() : lineText}
-                </p>
+                {/* concealed line shows a pulsing cue marker until revealed */}
+                {isConcealed ? (
+                  <p
+                    className="cue-dot font-script text-[1.2em] leading-relaxed text-accent"
+                    aria-label="Line hidden — press down arrow to reveal"
+                  >
+                    ···
+                  </p>
+                ) : (
+                  <p
+                    key={`${currentLineIndex}-${wordDisplayIndex > 0 ? "revealed" : "hidden"}`}
+                    className={`line-enter font-script text-[1.2em] leading-relaxed ${isSung ? "italic" : ""} ${getLineColorClass(currentChars)}`}
+                  >
+                    {isSung ? lineText.toUpperCase() : lineText}
+                  </p>
+                )}
               </div>
             </li>
           );

--- a/src/components/ScriptDisplay/ScriptBox.tsx
+++ b/src/components/ScriptDisplay/ScriptBox.tsx
@@ -321,7 +321,7 @@ export default function ScriptBox({ data }: ScriptBoxProps) {
   });
 
   return (
-    <div className="flex h-[90dvh] w-[95dvw] flex-col rounded-md border-2 border-stone-200 supports-[height:100svh]:h-[90svh]">
+    <div className="flex h-[90dvh] w-[95dvw] flex-col overflow-hidden rounded-2xl border border-border bg-surface shadow-xl shadow-black/5 supports-[height:100svh]:h-[90svh] dark:shadow-black/40">
       <div className="flex h-[90%] flex-col rounded-md ">
         <div className="pt-safe-top pb-safe-bottom flex-grow overflow-hidden">
           <ul className="overscroll-bounce h-full overflow-y-auto px-2 [-webkit-overflow-scrolling:touch] [overscroll-behavior:contain] [touch-action:pan-y]">
@@ -336,18 +336,42 @@ export default function ScriptBox({ data }: ScriptBoxProps) {
               />
             ) : (
               <div className="flex h-full items-center justify-center">
-                <div className="text-center">
-                  <div className="mb-4">
-                    <h1 className="text-3xl font-bold text-stone-700">
-                      Welcome to Line Runner
-                    </h1>
-                    <h4 className="text-lg font-bold text-stone-700">
-                      by Corey
-                    </h4>
+                <div className="max-w-md px-6 text-center">
+                  {/* Playbill-style masthead */}
+                  <div className="mb-3 flex items-center justify-center gap-3">
+                    <span className="h-px w-10 bg-border" />
+                    <p className="text-xs font-semibold uppercase tracking-[0.35em] text-muted-foreground">
+                      LineRunner
+                    </p>
+                    <span className="h-px w-10 bg-border" />
                   </div>
-                  <p className="text-lg text-stone-700">
-                    Select a scene from the menu to begin
+                  <h1 className="font-display text-4xl font-semibold leading-tight md:text-5xl">
+                    Know <span className="italic text-accent">every</span> line.
+                  </h1>
+                  <p className="mt-4 font-script text-base text-muted-foreground">
+                    Open the menu, pick a scene and your character,
+                    <br className="hidden md:block" /> then press play.
                   </p>
+
+                  {/* Keyboard cues */}
+                  <div className="mt-10 hidden flex-col items-center gap-2.5 text-sm text-muted-foreground md:flex">
+                    <div className="flex items-center gap-2">
+                      <span className="kbd-chip">Space</span>
+                      <span>start the scene</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="kbd-chip">↓</span>
+                      <span>reveal line, then advance</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="kbd-chip">↑</span>
+                      <span>previous line</span>
+                      <span className="mx-1 text-border">·</span>
+                      <span className="kbd-chip">←</span>
+                      <span className="kbd-chip">→</span>
+                      <span>word by word</span>
+                    </div>
+                  </div>
                 </div>
               </div>
             )}

--- a/src/components/ScriptViewer.tsx
+++ b/src/components/ScriptViewer.tsx
@@ -141,14 +141,14 @@ export default function ScriptViewer({ data }: ScriptViewerProps) {
   };
 
   return (
-    <div className="flex h-[90dvh] w-[95dvw] flex-col rounded-md border-2 border-stone-200 bg-stone-100 supports-[height:100svh]:h-[90svh] dark:bg-stone-900">
-      <div className="flex h-full flex-col rounded-md">
+    <div className="flex h-[90dvh] w-[95dvw] flex-col overflow-hidden rounded-2xl border border-border bg-surface shadow-xl shadow-black/5 supports-[height:100svh]:h-[90svh] dark:shadow-black/40">
+      <div className="flex h-full flex-col">
         {/* Mobile-optimized header */}
-        <div className="iphone:flex-row iphone:items-center iphone:justify-between iphone:px-4 iphone:py-3 flex flex-col border-b border-stone-200 bg-stone-50 px-3 py-2 dark:border-stone-700 dark:bg-stone-800">
-          <h2 className="text-mobile-base iphone:text-lg iphone:mb-0 mb-1 font-semibold text-stone-900 dark:text-stone-100">
+        <div className="iphone:flex-row iphone:items-center iphone:justify-between iphone:px-4 iphone:py-3 flex flex-col border-b border-border bg-surface-raised/90 px-3 py-2">
+          <h2 className="text-mobile-base iphone:text-lg iphone:mb-0 mb-1 font-display font-semibold">
             Script Viewer
           </h2>
-          <div className="text-mobile-xs iphone:text-sm text-stone-600 dark:text-stone-400">
+          <div className="text-mobile-xs iphone:text-sm text-muted-foreground">
             {getStatusText()}
           </div>
         </div>
@@ -161,7 +161,7 @@ export default function ScriptViewer({ data }: ScriptViewerProps) {
             className="text-mobile-sm iphone:text-mobile-base iphone:leading-loose iphone:p-4 h-full min-h-[60px] 
                       resize-none overflow-y-auto border-0 
                       bg-transparent p-3
-                      font-mono leading-relaxed text-stone-900
+                      font-script leading-relaxed text-stone-900
                       [-webkit-overflow-scrolling:touch] [overscroll-behavior:contain] [touch-action:pan-y]
                       focus-visible:ring-0
                       dark:text-stone-100 md:text-sm"

--- a/src/components/SidebarClient.tsx
+++ b/src/components/SidebarClient.tsx
@@ -113,7 +113,7 @@ export function SidebarClient({
       {/* sidebar */}
       <div
         ref={sidebarRef}
-        className={`fixed left-0 top-0 h-full transform border-r border-stone-200 bg-stone-50/95 backdrop-blur-sm transition-all duration-500 ease-in-out dark:border-stone-800 dark:bg-stone-900/90 ${
+        className={`fixed left-0 top-0 h-full transform border-r border-border bg-surface/95 backdrop-blur-md transition-all duration-500 ease-in-out ${
           navOpen
             ? "w-[85vw] translate-x-0 opacity-100 xs:w-[80vw] iphone:w-[75vw] md:w-[33vw]"
             : "w-[85vw] -translate-x-full opacity-100 xs:w-[80vw] iphone:w-[75vw] md:w-[33vw]"
@@ -126,41 +126,46 @@ export function SidebarClient({
         >
           <div className="pt-3 iphone:pt-2">
             <div className="flex items-center justify-between p-2">
-              {/* Close button for mobile */}
-              <Button
-                onClick={() => setNavOpen(false)}
-                variant="ghost"
-                size="sm"
-                className="p-2 text-stone-600 hover:bg-stone-200 dark:text-stone-400 dark:hover:bg-stone-700 md:hidden"
-                aria-label="Close sidebar"
-              >
-                <IoClose className="h-5 w-5" />
-              </Button>
-              <div className="md:hidden" /> {/* Spacer for mobile */}
+              <div className="flex items-center gap-1">
+                {/* Close button for mobile */}
+                <Button
+                  onClick={() => setNavOpen(false)}
+                  variant="ghost"
+                  size="sm"
+                  className="p-2 text-muted-foreground hover:bg-muted md:hidden"
+                  aria-label="Close sidebar"
+                >
+                  <IoClose className="h-5 w-5" />
+                </Button>
+                {/* Wordmark */}
+                <span className="pl-1 font-display text-xl font-semibold tracking-tight">
+                  Line<span className="text-accent">Runner</span>
+                </span>
+              </div>
               <AuthButton />
             </div>
-            <div className=" px-2">
-              <p className="mb-2 text-mobile-base font-bold text-stone-900 dark:text-stone-100 iphone:text-base">
+            <div className="px-3 pt-2">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
                 Script Select
               </p>
               <NewScriptSelect projects={projects} allData={allData} />
             </div>
 
             {/* Settings */}
-            <div className="mt-4 px-2">
-              <p className="mb-2 text-mobile-base font-bold text-stone-900 dark:text-stone-100 iphone:text-base">
+            <div className="mt-5 px-3">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
                 Settings
               </p>
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
-                  <Label className="text-mobile-sm text-stone-800 dark:text-stone-200 iphone:text-sm">
+                  <Label className="text-mobile-sm iphone:text-sm">
                     Theme
                   </Label>
                   <ThemeToggle />
                 </div>
                 {isAdmin && (
                   <div className="flex items-center justify-between">
-                    <Label className="text-mobile-sm text-stone-800 dark:text-stone-200 iphone:text-sm">
+                    <Label className="text-mobile-sm iphone:text-sm">
                       Refresh Data
                     </Label>
                     <RefreshButton
@@ -175,8 +180,8 @@ export function SidebarClient({
             </div>
 
             {/* Display Settings */}
-            <div className="mt-4 border-t border-stone-200 px-2 pt-4 dark:border-stone-700">
-              <p className="mb-2 text-mobile-base font-bold text-stone-900 dark:text-stone-100 iphone:text-base">
+            <div className="mt-5 border-t border-border px-3 pt-4">
+              <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
                 Display
               </p>
               <DisplaySettings />
@@ -184,8 +189,8 @@ export function SidebarClient({
 
             {/* Project Sharing - Admin Only */}
             {isAdmin && (
-              <div className="mt-4 border-t border-stone-200 px-2 pt-4 dark:border-stone-700">
-                <p className="mb-2 text-mobile-base font-bold text-stone-900 dark:text-stone-100 iphone:text-base">
+              <div className="mt-5 border-t border-border px-3 pt-4">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
                   Project Sharing
                 </p>
                 <AdminSharingPanel />
@@ -193,14 +198,10 @@ export function SidebarClient({
             )}
 
           </div>
-          <div className="fixed bottom-[.5rem] pl-2">
+          <div className="fixed bottom-[.5rem] pl-3">
             <Link href="https://www.coreyloftus.com" target="_blank">
-              <div className="font-mono text-mobile-xs text-stone-600 dark:text-stone-400 iphone:text-sm">
-                LineRunner by Corey -- ©2025
-                <span className="text-stone-600 dark:text-stone-400">
-                  {" "}
-                  coreyloftus.com
-                </span>
+              <div className="font-script text-mobile-xs text-muted-foreground transition-colors hover:text-foreground iphone:text-sm">
+                LineRunner by Corey — ©2025 coreyloftus.com
               </div>
             </Link>
           </div>

--- a/src/components/ui/control-button.tsx
+++ b/src/components/ui/control-button.tsx
@@ -19,7 +19,7 @@ export function ControlButton({
   disabled = false,
 }: ControlButtonProps) {
   const baseClasses =
-    "flex items-center justify-center border border-stone-300 bg-stone-50 shadow-sm transition-all duration-200 hover:bg-stone-200 hover:shadow-md hover:scale-105 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-stone-50 disabled:active:scale-100 dark:border-stone-600 dark:bg-stone-700 dark:hover:bg-stone-600";
+    "flex items-center justify-center border border-border bg-surface shadow-sm transition-all duration-200 hover:border-accent/50 hover:bg-accent-soft hover:shadow-md active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-surface disabled:active:scale-100";
 
   const sizeClasses = {
     small: "h-full min-h-full w-11 min-w-[52px] rounded-full xs:w-12",
@@ -33,10 +33,9 @@ export function ControlButton({
   };
 
   const iconSizeClasses = {
-    small:
-      "text-lg text-stone-700 transition-colors duration-200 dark:text-stone-200",
+    small: "text-lg text-foreground/80 transition-colors duration-200",
     large:
-      "text-xl text-stone-700 xs:text-xl sm:text-2xl transition-colors duration-200 dark:text-stone-200",
+      "text-xl text-foreground/80 xs:text-xl sm:text-2xl transition-colors duration-200",
   };
 
   return (

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -15,9 +15,9 @@ const TabsList = React.forwardRef<
     ref={ref}
     className={cn(
       // Mobile-first design with touch targets
-      "inline-flex h-12 iphone:h-14 items-center justify-center rounded-lg bg-stone-100 p-1 text-stone-500 dark:bg-stone-800 dark:text-stone-400 [touch-action:manipulation]",
+      "inline-flex h-12 iphone:h-14 items-center justify-center rounded-xl border border-border bg-surface-raised/80 p-1 text-muted-foreground shadow-sm backdrop-blur-sm [touch-action:manipulation]",
       // Mobile spacing and overflow handling
-      "w-full max-w-md gap-2",
+      "w-full max-w-md gap-1",
       // Responsive grid for equal width tabs
       "grid grid-cols-4",
       className,
@@ -35,17 +35,17 @@ const TabsTrigger = React.forwardRef<
     ref={ref}
     className={cn(
       // Mobile-first touch targets and responsive design
-      "min-h-[44px] min-w-[44px] flex flex-col items-center justify-center gap-1 rounded-md transition-all [touch-action:manipulation]",
+      "min-h-[44px] min-w-[44px] flex flex-col items-center justify-center gap-1 rounded-lg transition-all duration-200 [touch-action:manipulation]",
       // Mobile typography - smaller on mobile, larger on desktop
       "text-mobile-xs iphone:text-mobile-sm md:text-sm font-medium",
       // Mobile padding - more generous touch area
       "px-1 py-2 iphone:px-2 md:px-3",
-      // Active state styling
-      "data-[state=active]:bg-newStyle-accent-color dark:data-[state=active]:bg-newStyle-accent-color",
-      "data-[state=active]:text-stone-950 data-[state=active]:shadow",
+      // Hover state for inactive tabs
+      "hover:text-foreground",
+      // Active state styling — spotlight amber
+      "data-[state=active]:bg-accent data-[state=active]:text-accent-foreground data-[state=active]:shadow data-[state=active]:font-semibold",
       // Focus and accessibility
-      "ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-950 focus-visible:ring-offset-2",
-      "dark:ring-offset-stone-950 dark:focus-visible:ring-stone-300 dark:data-[state=active]:text-stone-950",
+      "ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       // Disabled state
       "disabled:pointer-events-none disabled:opacity-50",
       // Responsive behavior
@@ -64,7 +64,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-950 focus-visible:ring-offset-2 dark:ring-offset-stone-950 dark:focus-visible:ring-stone-300",
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       className,
     )}
     {...props}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,15 +2,49 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Theme Variables */
+/* ------------------------------------------------------------------ */
+/* "The Prompt Book" theme                                            */
+/* Light: a script page — warm paper, ink, pencil.                    */
+/* Dark: house lights down — warm black stage, amber spotlight.       */
+/* ------------------------------------------------------------------ */
 :root {
-  --background: 0 0% 100%;
-  --foreground: 20 14.3% 4.1%;
+  --background: 42 42% 95%;
+  --foreground: 24 24% 12%;
+
+  --surface: 44 45% 97%;
+  --surface-raised: 42 38% 93%;
+
+  --muted: 40 22% 88%;
+  --muted-foreground: 28 10% 40%;
+
+  --border: 36 20% 82%;
+  --ring: 38 92% 44%;
+
+  --accent: 38 92% 46%;
+  --accent-soft: 40 85% 90%;
+  --accent-foreground: 26 40% 10%;
+
+  --curtain: 352 62% 42%;
 }
 
 .dark {
-  --background: 20 14.3% 4.1%;
-  --foreground: 0 0% 95%;
+  --background: 24 14% 6%;
+  --foreground: 40 28% 90%;
+
+  --surface: 24 12% 9%;
+  --surface-raised: 25 11% 12%;
+
+  --muted: 24 10% 16%;
+  --muted-foreground: 34 12% 62%;
+
+  --border: 25 10% 19%;
+  --ring: 41 96% 56%;
+
+  --accent: 41 96% 56%;
+  --accent-soft: 38 40% 15%;
+  --accent-foreground: 24 20% 7%;
+
+  --curtain: 352 70% 58%;
 }
 
 /* Apply theme colors to document */
@@ -20,9 +54,40 @@ body {
   color: hsl(var(--foreground));
 }
 
+/* Paper grain — a whisper of tooth on every surface */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.5;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.05'/%3E%3C/svg%3E");
+}
+
+/* Spotlight wash — dark mode only: a warm pool of light upstage center */
+.dark body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background: radial-gradient(
+    ellipse 90% 65% at 50% -10%,
+    hsl(41 96% 56% / 0.07),
+    transparent 65%
+  );
+}
+
+/* Everything renders above the texture layers */
+body > * {
+  position: relative;
+  z-index: 1;
+}
+
 .scrollbar-custom {
   scrollbar-width: thin; /* Firefox */
-  scrollbar-color: #a1a097 #a1a097; /* Color for Firefox */
+  scrollbar-color: hsl(var(--border)) transparent;
 }
 
 .scrollbar-custom::-webkit-scrollbar {
@@ -30,28 +95,16 @@ body {
 }
 
 .scrollbar-custom::-webkit-scrollbar-track {
-  background: #a1a097;
-  border-radius: 10px;
+  background: transparent;
 }
 
 .scrollbar-custom::-webkit-scrollbar-thumb {
-  background-color: #a1a097;
+  background-color: hsl(var(--border));
   border-radius: 10px;
-  border: 2px solid #a1a097;
 }
 
-/* Dark mode scrollbar */
-.dark .scrollbar-custom {
-  scrollbar-color: #57534e #292524; /* Color for Firefox */
-}
-
-.dark .scrollbar-custom::-webkit-scrollbar-track {
-  background: #292524;
-}
-
-.dark .scrollbar-custom::-webkit-scrollbar-thumb {
-  background-color: #57534e;
-  border: 2px solid #57534e;
+.scrollbar-custom::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground));
 }
 
 @keyframes blink-on-and-off {
@@ -67,4 +120,54 @@ body {
 
 .blink-on-and-off {
   animation: blink-on-and-off 2s ease-in-out infinite;
+}
+
+/* Line reveal — new lines rise gently into place */
+@keyframes line-enter {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.line-enter {
+  animation: line-enter 0.35s ease-out both;
+}
+
+/* Cue dot — pulsing marker for the live line awaiting reveal */
+@keyframes cue-pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.4;
+    transform: scale(0.8);
+  }
+}
+
+.cue-dot {
+  animation: cue-pulse 1.6s ease-in-out infinite;
+}
+
+/* Keyboard hint chips on the welcome screen */
+.kbd-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.375rem;
+  border: 1px solid hsl(var(--border));
+  border-bottom-width: 2px;
+  background: hsl(var(--surface));
+  font-family: var(--font-geist-sans), sans-serif;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: hsl(var(--muted-foreground));
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -26,12 +26,37 @@ const config = {
       },
       
       colors: {
-        "newStyle-accent-color": "#fbbf24", // yellow-400
+        // "Prompt Book" theme tokens — defined in globals.css
+        background: "hsl(var(--background) / <alpha-value>)",
+        foreground: "hsl(var(--foreground) / <alpha-value>)",
+        surface: {
+          DEFAULT: "hsl(var(--surface) / <alpha-value>)",
+          raised: "hsl(var(--surface-raised) / <alpha-value>)",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted) / <alpha-value>)",
+          foreground: "hsl(var(--muted-foreground) / <alpha-value>)",
+        },
+        border: "hsl(var(--border) / <alpha-value>)",
+        ring: "hsl(var(--ring) / <alpha-value>)",
+        accent: {
+          DEFAULT: "hsl(var(--accent) / <alpha-value>)",
+          soft: "hsl(var(--accent-soft) / <alpha-value>)",
+          foreground: "hsl(var(--accent-foreground) / <alpha-value>)",
+        },
+        curtain: "hsl(var(--curtain) / <alpha-value>)",
+        "newStyle-accent-color": "hsl(var(--accent) / <alpha-value>)",
         // Mobile-optimized colors for better contrast
         'mobile-contrast': {
           50: '#f8fafc',
           900: '#0f172a',
         }
+      },
+
+      fontFamily: {
+        sans: ["var(--font-geist-sans)", "sans-serif"],
+        display: ["var(--font-fraunces)", "Georgia", "serif"],
+        script: ["var(--font-courier-prime)", "Courier New", "monospace"],
       },
       
       // Mobile touch targets


### PR DESCRIPTION
## Summary
- **New "Prompt Book" design system**: light mode reads as a script page (warm paper + ink), dark mode as house-lights-down (warm black + amber spotlight). Full CSS token set (`--surface`, `--muted`, `--accent`, …) in `globals.css`, wired through Tailwind with alpha-value support, plus a subtle paper-grain texture and dark-mode spotlight wash.
- **Typography**: dialogue set in Courier Prime (screenplay standard), character names in letterspaced small caps, brand/headings in Fraunces — loaded via `next/font`.
- **Runner**: amber-highlighted current line, pulsing `···` cue dots while a line is concealed, gentle reveal animation, dimmed past lines; playbill-style welcome screen with keyboard hint chips.
- **Chrome**: restyled tab bar, control bar, sidebar (wordmark + small-caps section headers), and Script Viewer.
- **Bug fix**: selecting a project crashed the app with *Maximum update depth exceeded* — `NewScriptSelect`'s URL-sync effect created a fresh `selectedProject` object every render (regression from #44). Now bails out when name/source are unchanged.
- Also carries the earlier two-step character display commit from `fix/two-step-character-display` (no PR existed for it).

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (pre-existing warnings only)
- [x] Verified in browser: welcome screen, sidebar, project → character → scene selection (no crash), play + line navigation, concealed/revealed states — in both light and dark themes
- [ ] Sanity-check on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)