### PR TITLE
feat: unify script management into a Scripts workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ yarn-error.log*
 *.tsbuildinfo
 
 # scripts
-/scripts
+/scripts.playwright-mcp/

--- a/src/components/AddScriptDoc.tsx
+++ b/src/components/AddScriptDoc.tsx
@@ -613,12 +613,12 @@ export const AddScriptDoc = () => {
   // If user is not authenticated, show message
   if (!session?.user) {
     return (
-      <div className="flex h-[90dvh] w-[95dvw] flex-col items-center justify-center rounded-md border-2 border-stone-200 supports-[height:100svh]:h-[90svh]">
+      <div className="flex h-full w-full flex-col items-center justify-center">
         <div className="text-center">
-          <h2 className="mb-4 text-lg font-semibold text-stone-900 dark:text-stone-100">
+          <h2 className="mb-4 font-display text-lg font-semibold">
             Authentication Required
           </h2>
-          <p className="text-stone-600 dark:text-stone-400">
+          <p className="text-muted-foreground">
             Please sign in to add scripts to the database.
           </p>
         </div>
@@ -627,15 +627,15 @@ export const AddScriptDoc = () => {
   }
 
   return (
-    <div>
+    <div className="h-full w-full">
       <>
-        <div className="flex h-[90dvh] w-[95dvw] flex-col rounded-md border-2 border-stone-200 supports-[height:100svh]:h-[90svh]">
-          <div className="flex h-full flex-col rounded-md">
-            <div className="flex items-center justify-between rounded-md border-b border-stone-200 bg-stone-50 px-4 py-3 dark:border-stone-700 dark:bg-stone-800">
+        <div className="flex h-full w-full flex-col">
+          <div className="flex h-full flex-col">
+            <div className="flex items-center justify-between border-b border-border bg-surface-raised/60 px-4 py-2">
               <div className="flex items-center gap-4">
-                <h2 className="text-lg font-semibold text-stone-900 dark:text-stone-100">
-                  Add Script
-                </h2>
+                <p className="text-sm text-muted-foreground">
+                  Import a new script
+                </p>
               </div>
               {isAdmin && (
                 <div className="flex items-center gap-2">
@@ -660,7 +660,7 @@ export const AddScriptDoc = () => {
                 </p>
                 <div className="grid grid-cols-3 gap-2">
                   <div>
-                    <p className="mb-1 text-xs text-stone-900 dark:text-stone-100">
+                    <p className="mb-1 text-xs text-muted-foreground">
                       Collection:
                     </p>
                     <Select
@@ -680,7 +680,7 @@ export const AddScriptDoc = () => {
                     </Select>
                   </div>
                   <div>
-                    <p className="mb-1 text-xs text-stone-900 dark:text-stone-100">
+                    <p className="mb-1 text-xs text-muted-foreground">
                       Document ID:
                     </p>
                     <Select
@@ -700,7 +700,7 @@ export const AddScriptDoc = () => {
                     </Select>
                   </div>
                   <div>
-                    <p className="mb-1 text-xs text-stone-900 dark:text-stone-100">
+                    <p className="mb-1 text-xs text-muted-foreground">
                       Subcollection:
                     </p>
                     <Select
@@ -728,7 +728,7 @@ export const AddScriptDoc = () => {
                   </p>
                   <div className="grid grid-cols-2 gap-2">
                     <div>
-                      <p className="mb-1 text-xs text-stone-900 dark:text-stone-100">
+                      <p className="mb-1 text-xs text-muted-foreground">
                         Source User ID:
                       </p>
                       <Input
@@ -739,7 +739,7 @@ export const AddScriptDoc = () => {
                       />
                     </div>
                     <div>
-                      <p className="mb-1 text-xs text-stone-900 dark:text-stone-100">
+                      <p className="mb-1 text-xs text-muted-foreground">
                         Target User ID:
                       </p>
                       <Input
@@ -750,7 +750,7 @@ export const AddScriptDoc = () => {
                       />
                     </div>
                     <div className="col-span-2">
-                      <p className="mb-1 text-xs text-stone-900 dark:text-stone-100">
+                      <p className="mb-1 text-xs text-muted-foreground">
                         Project Name:
                       </p>
                       <div className="flex gap-2">
@@ -779,7 +779,7 @@ export const AddScriptDoc = () => {
             <div className="flex flex-col gap-2 p-2">
               <div className="flex flex-col gap-2 sm:flex-row">
                 <div className="flex-1">
-                  <p className="mb-1 text-sm text-stone-900 dark:text-stone-100">
+                  <p className="mb-1 text-sm">
                     Project Name:
                   </p>
                   <div className="space-y-2">
@@ -817,7 +817,7 @@ export const AddScriptDoc = () => {
                   </div>
                 </div>
                 <div className="flex-1">
-                  <p className="mb-1 text-sm text-stone-900 dark:text-stone-100">
+                  <p className="mb-1 text-sm">
                     Scene Title:
                   </p>
                   <Input
@@ -831,7 +831,7 @@ export const AddScriptDoc = () => {
 
             {/* inputs for character names */}
             <div className="flex flex-col gap-2 p-2">
-              <p className="text-sm text-stone-900 dark:text-stone-100">
+              <p className="text-sm">
                 Character names separated by commas:
               </p>
               <Input
@@ -845,22 +845,22 @@ export const AddScriptDoc = () => {
             {/* Input method tabs and content */}
             <div className="flex-1 flex flex-col">
               {/* Tabs */}
-              <div className="flex border-b border-stone-200 dark:border-stone-700">
+              <div className="flex border-b border-border">
                 <button
-                  className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                  className={`border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
                     inputMethod === "text"
-                      ? "border-blue-500 text-blue-600 dark:text-blue-400"
-                      : "border-transparent text-stone-600 dark:text-stone-400 hover:text-stone-800 dark:hover:text-stone-200"
+                      ? "border-accent text-foreground"
+                      : "border-transparent text-muted-foreground hover:text-foreground"
                   }`}
                   onClick={() => setInputMethod("text")}
                 >
                   Text Input
                 </button>
                 <button
-                  className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+                  className={`border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
                     inputMethod === "file"
-                      ? "border-blue-500 text-blue-600 dark:text-blue-400"
-                      : "border-transparent text-stone-600 dark:text-stone-400 hover:text-stone-800 dark:hover:text-stone-200"
+                      ? "border-accent text-foreground"
+                      : "border-transparent text-muted-foreground hover:text-foreground"
                   }`}
                   onClick={() => setInputMethod("file")}
                 >

--- a/src/components/AppContent.tsx
+++ b/src/components/AppContent.tsx
@@ -7,8 +7,7 @@ import { SidebarToggle } from "./SidebarToggle";
 import { SidebarClient } from "./SidebarClient";
 import ScriptBox from "./ScriptDisplay/ScriptBox";
 import ScriptViewer from "./ScriptViewer";
-import { ScriptData } from "./ScriptData";
-import { AddScriptDoc } from "./AddScriptDoc";
+import { ScriptsWorkspace } from "./ScriptsWorkspace";
 
 interface GetAllResponse {
   projects: string[];
@@ -22,6 +21,7 @@ interface AppContentProps {
 
 export function AppContent({ projectData, sidebarData }: AppContentProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState("runner");
 
   const handleSidebarToggle = () => {
     setSidebarOpen(!sidebarOpen);
@@ -42,10 +42,11 @@ export function AppContent({ projectData, sidebarData }: AppContentProps) {
       {/* Main Content */}
       <div className="pt-safe-top pb-safe-bottom flex min-h-[100dvh] flex-col items-center justify-center p-2 text-foreground transition-colors [touch-action:manipulation] supports-[height:100svh]:min-h-[100svh]">
         <Tabs
-          defaultValue="runner"
+          value={activeTab}
+          onValueChange={setActiveTab}
           className="flex w-full flex-1 flex-col items-center justify-center"
         >
-          <TabsList className="mb-2 mt-0 grid w-full max-w-none grid-cols-5 gap-0">
+          <TabsList className="mb-2 mt-0 grid w-full max-w-none grid-cols-4 gap-0">
             <div className="flex flex-1 items-center justify-center">
               <SidebarToggle
                 onToggle={handleSidebarToggle}
@@ -63,15 +64,10 @@ export function AppContent({ projectData, sidebarData }: AppContentProps) {
               <span className="iphone:inline hidden md:hidden">View</span>
               <span className="hidden md:inline">Line Viewer</span>
             </TabsTrigger>
-            <TabsTrigger value="scriptdata" className="flex-1">
-              <span className="iphone:hidden">✏️</span>
-              <span className="iphone:inline hidden md:hidden">Edit</span>
-              <span className="hidden md:inline">Script Data</span>
-            </TabsTrigger>
-            <TabsTrigger value="newlines" className="flex-1">
-              <span className="iphone:hidden">➕</span>
-              <span className="iphone:inline hidden md:hidden">Add</span>
-              <span className="hidden md:inline">Add Script</span>
+            <TabsTrigger value="scripts" className="flex-1">
+              <span className="iphone:hidden">📚</span>
+              <span className="iphone:inline hidden md:hidden">Scripts</span>
+              <span className="hidden md:inline">Scripts</span>
             </TabsTrigger>
           </TabsList>
           <TabsContent value="runner" className="mt-0">
@@ -80,11 +76,11 @@ export function AppContent({ projectData, sidebarData }: AppContentProps) {
           <TabsContent value="viewer" className="mt-0">
             <ScriptViewer data={projectData} />
           </TabsContent>
-          <TabsContent value="scriptdata" className="mt-0">
-            <ScriptData data={projectData} />
-          </TabsContent>
-          <TabsContent value="newlines" className="mt-0">
-            <AddScriptDoc />
+          <TabsContent value="scripts" className="mt-0">
+            <ScriptsWorkspace
+              data={projectData}
+              onPractice={() => setActiveTab("runner")}
+            />
           </TabsContent>
         </Tabs>
       </div>

--- a/src/components/ScriptData.tsx
+++ b/src/components/ScriptData.tsx
@@ -96,7 +96,7 @@ const SortableLineItem = ({
     <div
       ref={setNodeRef}
       style={style}
-      className="rounded-md border border-stone-200 bg-stone-100 p-3 dark:border-stone-700 dark:bg-stone-800"
+      className="rounded-xl border border-border bg-surface-raised/60 p-3"
     >
       {/* Mobile Layout */}
       <div className="md:hidden">
@@ -145,7 +145,7 @@ const SortableLineItem = ({
             placeholder="Line text"
             value={line.line}
             onChange={(e) => onUpdate(line.id, "line", e.target.value)}
-            className={`text-mobile-base min-h-[88px] resize-none border-stone-200 bg-stone-100 text-stone-900 placeholder:text-stone-400 focus:border-stone-500 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-100 ${errors[`line-${line.id}`] ? "border-red-500" : warnings[`line-${line.id}`] ? "border-yellow-500" : ""}`}
+            className={`text-mobile-base min-h-[88px] resize-none border-border bg-surface text-foreground placeholder:text-muted-foreground focus:border-ring ${errors[`line-${line.id}`] ? "border-red-500" : warnings[`line-${line.id}`] ? "border-yellow-500" : ""}`}
             rows={3}
           />
           {errors[`character-${line.id}`] && (
@@ -194,7 +194,7 @@ const SortableLineItem = ({
         </div>
 
         {/* Desktop: Line Number */}
-        <div className="col-span-1 pt-2 text-sm text-stone-900 dark:text-stone-600">
+        <div className="col-span-1 pt-2 text-sm text-muted-foreground">
           {index + 1}
         </div>
 
@@ -226,7 +226,7 @@ const SortableLineItem = ({
             placeholder="Line text"
             value={line.line}
             onChange={(e) => onUpdate(line.id, "line", e.target.value)}
-            className={`text-sm resize-none border-stone-200 bg-stone-100 text-stone-900 placeholder:text-stone-400 focus:border-stone-500 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-100 ${errors[`line-${line.id}`] ? "border-red-500" : warnings[`line-${line.id}`] ? "border-yellow-500" : ""}`}
+            className={`text-sm resize-none border-border bg-surface text-foreground placeholder:text-muted-foreground focus:border-ring ${errors[`line-${line.id}`] ? "border-red-500" : warnings[`line-${line.id}`] ? "border-yellow-500" : ""}`}
             rows={calculateTextareaRows(line.line)}
           />
           {errors[`line-${line.id}`] && (
@@ -246,7 +246,7 @@ const SortableLineItem = ({
               checked={line.sung}
               onCheckedChange={(checked) => onUpdate(line.id, "sung", checked)}
             />
-            <Label className="text-xs text-stone-900 dark:text-stone-600">
+            <Label className="text-xs text-muted-foreground">
               Sung
             </Label>
           </div>
@@ -354,9 +354,9 @@ export const ScriptData = ({ data }: ScriptDataProps) => {
 
   const currentData = getCurrentData();
 
-  // Only find script if all required context values are present
+  // Only find script if a project and scene are selected (character not needed to edit)
   const script =
-    selectedProject && selectedScene && selectedCharacter
+    selectedProject && selectedScene
       ? currentData.allData
           .find((project) => project.project === selectedProject.name)
           ?.scenes.find((scene) => scene.title === selectedScene)
@@ -764,12 +764,12 @@ export const ScriptData = ({ data }: ScriptDataProps) => {
   // If user is not authenticated, show message
   if (!session?.user) {
     return (
-      <div className="flex h-[90dvh] w-[95dvw] flex-col justify-center rounded-md border-2 border-stone-700 bg-stone-900 supports-[height:100svh]:h-[90svh]">
+      <div className="flex h-full w-full flex-col justify-center">
         <div className="px-4 text-center">
-          <h2 className="text-mobile-lg iphone:text-lg mb-4 font-semibold text-stone-100">
+          <h2 className="text-mobile-lg iphone:text-lg mb-4 font-display font-semibold">
             Authentication Required
           </h2>
-          <p className="text-mobile-base iphone:text-base text-stone-400">
+          <p className="text-mobile-base iphone:text-base text-muted-foreground">
             Please sign in to edit scripts.
           </p>
         </div>
@@ -778,19 +778,21 @@ export const ScriptData = ({ data }: ScriptDataProps) => {
   }
 
   return (
-    <div className="flex h-[90dvh] w-[95dvw] flex-col rounded-md border-2 border-stone-200 bg-stone-100 font-mono supports-[height:100svh]:h-[90svh] dark:border-stone-700 dark:bg-stone-900">
-      <div className="flex h-full flex-col rounded-md">
+    <div className="flex h-full w-full flex-col">
+      <div className="flex h-full flex-col">
         {/* Header */}
-        <div className="iphone:flex-row iphone:items-center iphone:justify-between iphone:space-y-0 iphone:px-4 iphone:py-3 flex flex-col space-y-2 border-b border-stone-200 bg-stone-50 px-3 py-2 dark:border-stone-700 dark:bg-stone-800">
-          <h2 className="text-mobile-base iphone:text-lg font-semibold text-stone-900 dark:text-stone-100">
-            Script Data Editor
-          </h2>
+        <div className="iphone:flex-row iphone:items-center iphone:justify-between iphone:space-y-0 iphone:px-4 iphone:py-2 flex flex-col space-y-2 border-b border-border bg-surface-raised/60 px-3 py-2">
+          <p className="text-mobile-sm iphone:text-sm truncate text-muted-foreground">
+            {script
+              ? `Editing: ${selectedProject?.name} — ${selectedScene}`
+              : "Scene Editor"}
+          </p>
           <Button
             onClick={handleSave}
             disabled={!hasChanges || updateScriptMutation.isPending || !script || (editorMode === "json" && !!jsonError)}
             variant="outline"
             size="sm"
-            className="iphone:min-h-[36px] min-h-[44px] touch-manipulation border-stone-600 bg-stone-700 text-stone-100 hover:bg-stone-600 active:bg-stone-600 dark:border-stone-600 dark:bg-stone-700 dark:text-stone-100 dark:hover:bg-stone-600"
+            className="iphone:min-h-[36px] min-h-[44px] touch-manipulation"
           >
             {updateScriptMutation.isPending ? "Saving..." : "Save Script"}
           </Button>
@@ -800,9 +802,8 @@ export const ScriptData = ({ data }: ScriptDataProps) => {
         <div className="iphone:p-4 flex-1 overflow-auto p-3 [-webkit-overflow-scrolling:touch] [overscroll-behavior:contain] [touch-action:pan-y]">
           {!script ? (
             <div className="flex h-full items-center justify-center text-center">
-              <p className="text-stone-900 dark:text-stone-400">
-                Please select a project, scene, and character to edit script
-                data.
+              <p className="font-script text-muted-foreground">
+                Choose a scene from the Library to start editing.
               </p>
             </div>
           ) : (
@@ -812,7 +813,7 @@ export const ScriptData = ({ data }: ScriptDataProps) => {
                 <div className="space-y-2">
                   <Label
                     htmlFor="projectName"
-                    className="text-mobile-sm iphone:text-sm text-stone-900 dark:text-stone-200"
+                    className="text-mobile-sm iphone:text-sm"
                   >
                     Project Name
                   </Label>
@@ -820,7 +821,7 @@ export const ScriptData = ({ data }: ScriptDataProps) => {
                     id="projectName"
                     value={formData.projectName}
                     onChange={(e) => handleProjectNameChange(e.target.value)}
-                    className={`iphone:min-h-[36px] text-mobile-base iphone:text-sm min-h-[44px] border-stone-200 bg-stone-100 text-stone-900 placeholder:text-stone-400 focus:border-stone-500 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-100 ${errors.projectName ? "border-red-500" : ""}`}
+                    className={`iphone:min-h-[36px] text-mobile-base iphone:text-sm min-h-[44px] border-border bg-surface text-foreground placeholder:text-muted-foreground focus:border-ring ${errors.projectName ? "border-red-500" : ""}`}
                   />
                   {errors.projectName && (
                     <p className="text-mobile-xs iphone:text-sm text-red-400">
@@ -831,7 +832,7 @@ export const ScriptData = ({ data }: ScriptDataProps) => {
                 <div className="space-y-2">
                   <Label
                     htmlFor="sceneTitle"
-                    className="text-mobile-sm iphone:text-sm text-stone-900 dark:text-stone-200"
+                    className="text-mobile-sm iphone:text-sm"
                   >
                     Scene Title
                   </Label>
@@ -839,7 +840,7 @@ export const ScriptData = ({ data }: ScriptDataProps) => {
                     id="sceneTitle"
                     value={formData.sceneTitle}
                     onChange={(e) => handleSceneTitleChange(e.target.value)}
-                    className={`iphone:min-h-[36px] text-mobile-base iphone:text-sm min-h-[44px] border-stone-200 bg-stone-100 text-stone-900 placeholder:text-stone-400 focus:border-stone-500 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-100 ${errors.sceneTitle ? "border-red-500" : ""}`}
+                    className={`iphone:min-h-[36px] text-mobile-base iphone:text-sm min-h-[44px] border-border bg-surface text-foreground placeholder:text-muted-foreground focus:border-ring ${errors.sceneTitle ? "border-red-500" : ""}`}
                   />
                   {errors.sceneTitle && (
                     <p className="text-mobile-xs iphone:text-sm text-red-400">
@@ -852,19 +853,19 @@ export const ScriptData = ({ data }: ScriptDataProps) => {
               {/* Lines Section */}
               <div className="space-y-4">
                 <div className="iphone:flex-row iphone:items-center iphone:justify-between iphone:space-y-0 flex flex-col space-y-2">
-                  <h3 className="text-mobile-lg iphone:text-lg font-medium text-stone-100">
+                  <h3 className="text-mobile-lg iphone:text-lg font-display font-medium text-foreground">
                     Lines ({formData.lines.length})
                   </h3>
                   <div className="flex items-center gap-2">
                     {/* Editor Mode Toggle */}
-                    <div className="flex rounded-md border border-stone-600 bg-stone-800">
+                    <div className="flex rounded-md border border-border bg-surface p-0.5">
                       <button
                         type="button"
                         onClick={() => handleModeSwitch("form")}
-                        className={`px-3 py-1.5 text-sm transition-colors ${
+                        className={`rounded px-3 py-1.5 text-sm transition-colors ${
                           editorMode === "form"
-                            ? "bg-stone-600 text-stone-100"
-                            : "text-stone-400 hover:text-stone-200"
+                            ? "bg-accent font-medium text-accent-foreground"
+                            : "text-muted-foreground hover:text-foreground"
                         }`}
                       >
                         Form
@@ -872,10 +873,10 @@ export const ScriptData = ({ data }: ScriptDataProps) => {
                       <button
                         type="button"
                         onClick={() => handleModeSwitch("json")}
-                        className={`px-3 py-1.5 text-sm transition-colors ${
+                        className={`rounded px-3 py-1.5 text-sm transition-colors ${
                           editorMode === "json"
-                            ? "bg-stone-600 text-stone-100"
-                            : "text-stone-400 hover:text-stone-200"
+                            ? "bg-accent font-medium text-accent-foreground"
+                            : "text-muted-foreground hover:text-foreground"
                         }`}
                       >
                         JSON
@@ -886,7 +887,7 @@ export const ScriptData = ({ data }: ScriptDataProps) => {
                         onClick={addLine}
                         variant="outline"
                         size="sm"
-                        className="iphone:min-h-[36px] min-h-[44px] touch-manipulation border-stone-600 bg-stone-700 text-stone-100 hover:bg-stone-600 active:bg-stone-600"
+                        className="iphone:min-h-[36px] min-h-[44px] touch-manipulation"
                       >
                         Add Line
                       </Button>
@@ -936,7 +937,7 @@ export const ScriptData = ({ data }: ScriptDataProps) => {
                           onClick={addLine}
                           variant="outline"
                           size="sm"
-                          className="iphone:min-h-[36px] min-h-[44px] touch-manipulation border-stone-600 bg-stone-700 text-stone-100 hover:bg-stone-600 active:bg-stone-600"
+                          className="iphone:min-h-[36px] min-h-[44px] touch-manipulation"
                         >
                           Add Line
                         </Button>
@@ -959,7 +960,7 @@ export const ScriptData = ({ data }: ScriptDataProps) => {
                     <Textarea
                       value={jsonText}
                       onChange={(e) => handleJsonChange(e.target.value)}
-                      className={`min-h-[400px] font-mono text-sm border-stone-200 bg-stone-100 text-stone-900 placeholder:text-stone-400 focus:border-stone-500 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-100 ${jsonError ? "border-red-500" : ""}`}
+                      className={`min-h-[400px] font-mono text-sm border-border bg-surface text-foreground placeholder:text-muted-foreground focus:border-ring ${jsonError ? "border-red-500" : ""}`}
                       placeholder='{"title": "Scene Title", "lines": [{"characters": ["Character Name"], "line": "Dialogue text", "sung": false}]}'
                     />
                   </div>
@@ -967,11 +968,11 @@ export const ScriptData = ({ data }: ScriptDataProps) => {
               </div>
 
               {/* Bottom Save Button */}
-              <div className="flex justify-center border-t border-stone-700 pt-4">
+              <div className="flex justify-center border-t border-border pt-4">
                 <Button
                   onClick={handleSave}
                   disabled={!hasChanges || updateScriptMutation.isPending || (editorMode === "json" && !!jsonError)}
-                  className="min-h-[44px] touch-manipulation bg-blue-600 px-8 text-white hover:bg-blue-700 active:bg-blue-800 disabled:bg-stone-600 disabled:text-stone-400"
+                  className="min-h-[44px] touch-manipulation bg-accent px-8 text-accent-foreground hover:bg-accent/90"
                 >
                   {updateScriptMutation.isPending ? "Saving..." : "Save Script"}
                 </Button>

--- a/src/components/ScriptsWorkspace.tsx
+++ b/src/components/ScriptsWorkspace.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { useContext, useMemo, useState } from "react";
+import { useSession } from "next-auth/react";
+import { FaPlay, FaPen, FaPlus, FaChevronDown } from "react-icons/fa6";
+import { type ProjectJSON } from "~/server/api/routers/scriptData";
+import { ScriptContext, type ProjectSource } from "~/app/context";
+import { api } from "~/trpc/react";
+import { Button } from "./ui/button";
+import { ScriptData } from "./ScriptData";
+import { AddScriptDoc } from "./AddScriptDoc";
+
+interface GetAllResponse {
+  projects: string[];
+  allData: ProjectJSON[];
+}
+
+interface ScriptsWorkspaceProps {
+  data: GetAllResponse;
+  onPractice: () => void;
+}
+
+type WorkspaceView = "library" | "editor" | "new";
+
+interface LibrarySection {
+  key: ProjectSource;
+  title: string;
+  projects: ProjectJSON[];
+  emptyNote?: string;
+}
+
+const VIEW_LABELS: { value: WorkspaceView; label: string }[] = [
+  { value: "library", label: "Library" },
+  { value: "editor", label: "Editor" },
+  { value: "new", label: "Add New" },
+];
+
+export function ScriptsWorkspace({ data, onPractice }: ScriptsWorkspaceProps) {
+  const { data: session } = useSession();
+  const {
+    setSelectedProject,
+    setSelectedScene,
+    setSelectedCharacter,
+    selectedProject,
+    selectedScene,
+  } = useContext(ScriptContext);
+  const [view, setView] = useState<WorkspaceView>("library");
+  const [expandedProject, setExpandedProject] = useState<string | null>(null);
+
+  const { data: publicData } = api.scriptData.getAll.useQuery(
+    { dataSource: "public" },
+    { refetchOnWindowFocus: false },
+  );
+  const { data: sharedData } = api.scriptData.getAll.useQuery(
+    { dataSource: "shared" },
+    { enabled: !!session?.user, refetchOnWindowFocus: false },
+  );
+  const { data: userData } = api.scriptData.getAll.useQuery(
+    { dataSource: "firestore" },
+    { enabled: !!session?.user, refetchOnWindowFocus: false },
+  );
+
+  const sections: LibrarySection[] = useMemo(
+    () => [
+      {
+        key: "user",
+        title: "Your Scripts",
+        projects: userData?.allData ?? [],
+        emptyNote: session?.user
+          ? "Nothing here yet — import a script with Add New."
+          : "Sign in to keep your own scripts.",
+      },
+      {
+        key: "shared",
+        title: "Shared With You",
+        projects: sharedData?.allData ?? [],
+      },
+      {
+        key: "public",
+        title: "Public Library",
+        projects: publicData?.allData ?? data.allData,
+      },
+    ],
+    [userData, sharedData, publicData, data, session],
+  );
+
+  const projectCharacters = (project: ProjectJSON) => {
+    const chars = project.scenes.flatMap((scene) =>
+      scene.lines.flatMap((line) => line.characters),
+    );
+    return [...new Set(chars)];
+  };
+
+  const selectScene = (
+    project: ProjectJSON,
+    source: ProjectSource,
+    sceneTitle: string,
+  ) => {
+    setSelectedProject({ name: project.project, source });
+    setSelectedScene(sceneTitle);
+    setSelectedCharacter("");
+  };
+
+  const handleEdit = (
+    project: ProjectJSON,
+    source: ProjectSource,
+    sceneTitle: string,
+  ) => {
+    selectScene(project, source, sceneTitle);
+    setView("editor");
+  };
+
+  const handlePractice = (
+    project: ProjectJSON,
+    source: ProjectSource,
+    sceneTitle: string,
+  ) => {
+    selectScene(project, source, sceneTitle);
+    onPractice();
+  };
+
+  return (
+    <div className="flex h-[90dvh] w-[95dvw] flex-col overflow-hidden rounded-2xl border border-border bg-surface shadow-xl shadow-black/5 supports-[height:100svh]:h-[90svh] dark:shadow-black/40">
+      {/* Workspace header */}
+      <div className="flex items-center justify-between border-b border-border bg-surface-raised/90 px-3 py-2 iphone:px-4">
+        <h2 className="font-display text-mobile-base font-semibold iphone:text-lg">
+          Scripts
+        </h2>
+        <div className="flex rounded-lg border border-border bg-surface p-0.5">
+          {VIEW_LABELS.map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setView(value)}
+              className={`rounded-md px-3 py-1.5 text-mobile-xs font-medium transition-colors iphone:text-sm ${
+                view === value
+                  ? "bg-accent font-semibold text-accent-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="min-h-0 flex-1">
+        {view === "library" && (
+          <div className="h-full overflow-y-auto p-3 [-webkit-overflow-scrolling:touch] [overscroll-behavior:contain] iphone:p-4">
+            <div className="mx-auto max-w-3xl space-y-6">
+              {sections.map((section) => (
+                <section key={section.key}>
+                  <div className="mb-2 flex items-center gap-3">
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                      {section.title}
+                    </p>
+                    <span className="h-px flex-1 bg-border" />
+                    {section.key === "user" && session?.user && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setView("new")}
+                        className="gap-1.5"
+                      >
+                        <FaPlus className="h-3 w-3" />
+                        New Script
+                      </Button>
+                    )}
+                  </div>
+
+                  {section.projects.length === 0 ? (
+                    <p className="py-3 font-script text-sm text-muted-foreground">
+                      {section.emptyNote ?? "Nothing here yet."}
+                    </p>
+                  ) : (
+                    <div className="space-y-2">
+                      {section.projects.map((project) => {
+                        const projectKey = `${section.key}:${project.project}`;
+                        const isExpanded = expandedProject === projectKey;
+                        const characters = projectCharacters(project);
+                        return (
+                          <div
+                            key={projectKey}
+                            className="overflow-hidden rounded-xl border border-border bg-surface-raised/60"
+                          >
+                            <button
+                              type="button"
+                              onClick={() =>
+                                setExpandedProject(
+                                  isExpanded ? null : projectKey,
+                                )
+                              }
+                              className="flex w-full items-center justify-between gap-3 px-3 py-3 text-left transition-colors hover:bg-muted/50 iphone:px-4"
+                            >
+                              <div className="min-w-0">
+                                <p className="truncate font-display text-base font-semibold">
+                                  {project.project}
+                                </p>
+                                <p className="truncate text-xs text-muted-foreground">
+                                  {project.scenes.length}{" "}
+                                  {project.scenes.length === 1
+                                    ? "scene"
+                                    : "scenes"}
+                                  {characters.length > 0 && (
+                                    <> · {characters.slice(0, 4).join(", ")}
+                                    {characters.length > 4 &&
+                                      ` +${characters.length - 4}`}</>
+                                  )}
+                                </p>
+                              </div>
+                              <FaChevronDown
+                                className={`h-3.5 w-3.5 flex-shrink-0 text-muted-foreground transition-transform ${isExpanded ? "rotate-180" : ""}`}
+                              />
+                            </button>
+
+                            {isExpanded && (
+                              <ul className="border-t border-border">
+                                {project.scenes.map((scene) => {
+                                  const isCurrent =
+                                    selectedProject?.name === project.project &&
+                                    selectedProject.source === section.key &&
+                                    selectedScene === scene.title;
+                                  return (
+                                    <li
+                                      key={scene.title}
+                                      className={`flex items-center justify-between gap-2 px-3 py-2 iphone:px-4 ${isCurrent ? "bg-accent/10" : ""}`}
+                                    >
+                                      <div className="min-w-0">
+                                        <p className="truncate text-sm">
+                                          {scene.title}
+                                        </p>
+                                        <p className="text-xs text-muted-foreground">
+                                          {scene.lines.length}{" "}
+                                          {scene.lines.length === 1
+                                            ? "line"
+                                            : "lines"}
+                                        </p>
+                                      </div>
+                                      <div className="flex flex-shrink-0 gap-1.5">
+                                        <Button
+                                          variant="outline"
+                                          size="sm"
+                                          onClick={() =>
+                                            handlePractice(
+                                              project,
+                                              section.key,
+                                              scene.title,
+                                            )
+                                          }
+                                          className="gap-1.5"
+                                          aria-label={`Practice ${scene.title}`}
+                                        >
+                                          <FaPlay className="h-3 w-3" />
+                                          <span className="hidden iphone:inline">
+                                            Practice
+                                          </span>
+                                        </Button>
+                                        <Button
+                                          variant="outline"
+                                          size="sm"
+                                          onClick={() =>
+                                            handleEdit(
+                                              project,
+                                              section.key,
+                                              scene.title,
+                                            )
+                                          }
+                                          className="gap-1.5"
+                                          aria-label={`Edit ${scene.title}`}
+                                        >
+                                          <FaPen className="h-3 w-3" />
+                                          <span className="hidden iphone:inline">
+                                            Edit
+                                          </span>
+                                        </Button>
+                                      </div>
+                                    </li>
+                                  );
+                                })}
+                              </ul>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </section>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {view === "editor" && <ScriptData data={data} />}
+        {view === "new" && <AddScriptDoc />}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
> Stacked on #47.

## Summary
- Merges the "Script Data" and "Add Script" tabs into a single **Scripts** tab with three views: **Library / Editor / Add New**
- New Library view: browse *Your Scripts*, *Shared With You*, and the *Public Library*; expand any project to see its scenes with line counts and characters
- Every scene row has **Practice** (selects it and jumps straight to the Line Runner) and **Edit** (opens it in the editor) — no more juggling three sidebar dropdowns to get to work on a script
- The existing editor (drag-and-drop + JSON mode) and import flow are embedded unchanged logically, restyled with the Prompt Book design tokens
- Editing no longer requires a character to be selected
- Tabs in `AppContent` are now controlled so the library can navigate to the runner

## Test plan
- [x] `npm run build`, `npm run lint`, `tsc --noEmit` pass
- [x] Verified in browser: library renders all sections, project expands, Practice jumps to the runner with the scene loaded and playable, Editor shows the auth gate signed-out
- [ ] Signed-in check: edit + save a scene, import a new script

🤖 Generated with [Claude Code](https://claude.com/claude-code)