### PR TITLE
feat: speech-recognition line matching + scene-partner voice stub

### DIFF
--- a/src/app/context.tsx
+++ b/src/app/context.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
   type ReactNode,
   useEffect,
+  useRef,
 } from "react";
 import { useSearchParams } from "next/navigation";
 import { type GetAllResponse } from "~/server/api/routers/scriptData";
@@ -57,6 +58,9 @@ interface ScriptContextProps {
   // Display preferences
   displayPreferences: DisplayPreferences;
   setDisplayPreferences: Dispatch<SetStateAction<DisplayPreferences>>;
+  // Speech recognition line matching
+  speechMatchEnabled: boolean;
+  setSpeechMatchEnabled: Dispatch<SetStateAction<boolean>>;
 }
 
 type UserConfig = {
@@ -136,6 +140,9 @@ export const ScriptContext = createContext<ScriptContextProps>({
   // Display preferences defaults
   displayPreferences: DEFAULT_DISPLAY_PREFERENCES,
   setDisplayPreferences: () => DEFAULT_DISPLAY_PREFERENCES,
+  // Speech matching defaults
+  speechMatchEnabled: false,
+  setSpeechMatchEnabled: () => false,
 });
 
 export const ScriptProvider = ({ children }: { children: ReactNode }) => {
@@ -196,6 +203,24 @@ export const ScriptProvider = ({ children }: { children: ReactNode }) => {
       }
       return DEFAULT_DISPLAY_PREFERENCES;
     });
+
+  // Speech matching preference. Read from localStorage after mount (not in
+  // the initializer) so the SSR markup matches the first client render.
+  const [speechMatchEnabled, setSpeechMatchEnabled] = useState(false);
+  const speechMatchLoaded = useRef(false);
+
+  useEffect(() => {
+    setSpeechMatchEnabled(
+      localStorage.getItem("linerunner-speech-match") === "true",
+    );
+    speechMatchLoaded.current = true;
+  }, []);
+
+  // Persist speech matching preference (skip until the saved value is loaded)
+  useEffect(() => {
+    if (!speechMatchLoaded.current) return;
+    localStorage.setItem("linerunner-speech-match", String(speechMatchEnabled));
+  }, [speechMatchEnabled]);
 
   useEffect(() => {
     setQueryParams(Object.fromEntries(searchParams));
@@ -264,6 +289,9 @@ export const ScriptProvider = ({ children }: { children: ReactNode }) => {
         // Display preferences
         displayPreferences,
         setDisplayPreferences,
+        // Speech matching
+        speechMatchEnabled,
+        setSpeechMatchEnabled,
       }}
     >
       {children}

--- a/src/components/ScriptDisplay/ScriptBox.tsx
+++ b/src/components/ScriptDisplay/ScriptBox.tsx
@@ -2,12 +2,14 @@
 import { useCallback, useContext, useEffect, useState, useRef } from "react";
 // import { Button } from "../ui/button";
 // import { Input } from "../ui/input";
+import { FaMicrophone } from "react-icons/fa6";
 import { ScriptContext } from "~/app/context";
 import { type ProjectJSON } from "../../server/api/routers/scriptData";
 import ControlBar from "../ControlBar";
 import { CharacterLineDisplay } from "./CharacterLineDisplay";
 import { api } from "~/trpc/react";
 import { useSession } from "next-auth/react";
+import { useSpeechMatch } from "~/hooks/useSpeechMatch";
 
 // Helper to check if user is in the line's characters (outside component for memoization)
 const checkIsUserLine = (
@@ -42,6 +44,7 @@ export default function ScriptBox({ data }: ScriptBoxProps) {
     setAwaitingInput,
     currentLineSplit,
     setCurrentLineSplit,
+    speechMatchEnabled,
   } = useContext(ScriptContext);
 
   // Fetch public, shared, and user data
@@ -320,6 +323,40 @@ export default function ScriptBox({ data }: ScriptBoxProps) {
     }
   });
 
+  // --- Speech recognition line matching ---
+  const currentScriptLine = script?.lines[currentLineIndex];
+  const isUsersLine = checkIsUserLine(
+    currentScriptLine?.characters,
+    selectedCharacter,
+  );
+  const speechActive =
+    speechMatchEnabled && playScene && isUsersLine && !!currentScriptLine;
+
+  // The advance fires from a timeout, so route it through a ref to always
+  // call the latest navigation handler
+  const lineNavRef = useRef(handleLineNavigation);
+  useEffect(() => {
+    lineNavRef.current = handleLineNavigation;
+  });
+
+  const handleSpeechMatch = useCallback(() => {
+    // Reveal the full line so the actor sees they nailed it...
+    setWordIndex(currentLineSplit.length);
+    // ...then advance to the next line after a beat
+    window.setTimeout(() => lineNavRef.current("down"), 900);
+  }, [currentLineSplit.length, setWordIndex]);
+
+  const {
+    supported: speechSupported,
+    listening,
+    transcript,
+    ratio,
+  } = useSpeechMatch({
+    targetText: currentScriptLine?.line ?? "",
+    active: speechActive,
+    onMatch: handleSpeechMatch,
+  });
+
   return (
     <div className="flex h-[90dvh] w-[95dvw] flex-col overflow-hidden rounded-2xl border border-border bg-surface shadow-xl shadow-black/5 supports-[height:100svh]:h-[90svh] dark:shadow-black/40">
       <div className="flex h-[90%] flex-col rounded-md ">
@@ -399,6 +436,26 @@ export default function ScriptBox({ data }: ScriptBoxProps) {
             </div>
           </div>
         ) : null} */}
+        {/* Speech match status — visible while listening for the user's line */}
+        {speechActive && speechSupported && (
+          <div className="flex items-center gap-3 border-t border-border bg-accent/5 px-4 py-2">
+            <FaMicrophone
+              className={`h-4 w-4 flex-shrink-0 ${listening ? "blink-on-and-off text-accent" : "text-muted-foreground"}`}
+              aria-label={listening ? "Listening" : "Microphone idle"}
+            />
+            <div className="min-w-0 flex-1">
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full rounded-full bg-accent transition-[width] duration-300"
+                  style={{ width: `${Math.round(ratio * 100)}%` }}
+                />
+              </div>
+              <p className="mt-1 truncate font-script text-xs text-muted-foreground">
+                {transcript || "Say your line…"}
+              </p>
+            </div>
+          </div>
+        )}
       </div>
       <div className="h-[10%]">
         <ControlBar

--- a/src/components/SidebarClient.tsx
+++ b/src/components/SidebarClient.tsx
@@ -7,6 +7,7 @@ import { IoClose } from "react-icons/io5";
 import { ScriptContext } from "~/app/context";
 import { AuthButton } from "./AuthButton";
 import { Label } from "./ui/label";
+import { Switch } from "./ui/switch";
 import { RefreshButton } from "./ui/refresh-button";
 import { useScriptData } from "~/hooks/useScriptData";
 import { ThemeToggle } from "./ui/theme-toggle";
@@ -43,7 +44,8 @@ export function SidebarClient({
   );
 
   const setNavOpen = setNavOpenStable;
-  const { userConfig, isAdmin } = useContext(ScriptContext);
+  const { userConfig, isAdmin, speechMatchEnabled, setSpeechMatchEnabled } =
+    useContext(ScriptContext);
   const sidebarRef = useRef<HTMLDivElement>(null);
 
   // Get refresh functionality from the optimized hook
@@ -162,6 +164,36 @@ export function SidebarClient({
                     Theme
                   </Label>
                   <ThemeToggle />
+                </div>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <Label className="text-mobile-sm iphone:text-sm">
+                      Speech Match
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Say your line to advance (Chrome/Safari)
+                    </p>
+                  </div>
+                  <Switch
+                    checked={speechMatchEnabled}
+                    onCheckedChange={setSpeechMatchEnabled}
+                    aria-label="Toggle speech match"
+                  />
+                </div>
+                <div className="flex items-center justify-between opacity-60">
+                  <div>
+                    <Label className="text-mobile-sm iphone:text-sm">
+                      Scene Partner Voice
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      Coming soon — hear the other characters
+                    </p>
+                  </div>
+                  <Switch
+                    checked={false}
+                    disabled
+                    aria-label="Scene partner voice (coming soon)"
+                  />
                 </div>
                 {isAdmin && (
                   <div className="flex items-center justify-between">

--- a/src/hooks/useSpeechMatch.ts
+++ b/src/hooks/useSpeechMatch.ts
@@ -1,0 +1,201 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// The Web Speech API isn't in TypeScript's dom lib yet — declare what we use
+interface SpeechRecognitionResultLike {
+  isFinal: boolean;
+  0: { transcript: string };
+}
+
+interface SpeechRecognitionEventLike {
+  resultIndex: number;
+  results: {
+    length: number;
+    [index: number]: SpeechRecognitionResultLike;
+  };
+}
+
+interface SpeechRecognitionLike {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  start: () => void;
+  stop: () => void;
+  abort: () => void;
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null;
+  onend: (() => void) | null;
+  onerror: ((event: { error: string }) => void) | null;
+}
+
+type SpeechRecognitionConstructor = new () => SpeechRecognitionLike;
+
+const getSpeechRecognition = (): SpeechRecognitionConstructor | null => {
+  if (typeof window === "undefined") return null;
+  const w = window as unknown as {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  };
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
+};
+
+/** Lowercase, drop apostrophes ("didn't" ≡ "didnt"), strip punctuation, split */
+export const normalizeWords = (text: string): string[] =>
+  text
+    .toLowerCase()
+    .replace(/['’]/g, "")
+    .replace(/[^\p{L}\p{N} ]+/gu, " ")
+    .split(/\s+/)
+    .filter(Boolean);
+
+/**
+ * How much of `target` has been spoken, in order — the longest common
+ * subsequence of normalized words over the target length. Forgiving of
+ * filler words and recognition noise on both sides, strict about order.
+ */
+export const matchRatio = (spoken: string, target: string): number => {
+  const targetWords = normalizeWords(target);
+  if (targetWords.length === 0) return 0;
+  const spokenWords = normalizeWords(spoken);
+  if (spokenWords.length === 0) return 0;
+
+  const cols = targetWords.length + 1;
+  let prev = new Array<number>(cols).fill(0);
+  let curr = new Array<number>(cols).fill(0);
+  for (const spokenWord of spokenWords) {
+    for (let j = 1; j < cols; j++) {
+      curr[j] =
+        spokenWord === targetWords[j - 1]
+          ? (prev[j - 1] ?? 0) + 1
+          : Math.max(prev[j] ?? 0, curr[j - 1] ?? 0);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return (prev[cols - 1] ?? 0) / targetWords.length;
+};
+
+export interface UseSpeechMatchOptions {
+  /** The line the actor is supposed to say */
+  targetText: string;
+  /** Only listen while this is true */
+  active: boolean;
+  /** Ratio of target words (0-1) that counts as a match */
+  threshold?: number;
+  /** Called once when the spoken text matches the target */
+  onMatch: () => void;
+}
+
+export function useSpeechMatch({
+  targetText,
+  active,
+  threshold = 0.8,
+  onMatch,
+}: UseSpeechMatchOptions) {
+  const [supported, setSupported] = useState(false);
+  const [listening, setListening] = useState(false);
+  const [transcript, setTranscript] = useState("");
+  const [ratio, setRatio] = useState(0);
+
+  const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
+  const matchedRef = useRef(false);
+  // Keep the latest values in refs so the recognition callback never goes stale
+  const targetRef = useRef(targetText);
+  const onMatchRef = useRef(onMatch);
+  targetRef.current = targetText;
+  onMatchRef.current = onMatch;
+
+  useEffect(() => {
+    setSupported(getSpeechRecognition() !== null);
+  }, []);
+
+  // Reset per-line state whenever the target line changes
+  useEffect(() => {
+    matchedRef.current = false;
+    setTranscript("");
+    setRatio(0);
+  }, [targetText]);
+
+  useEffect(() => {
+    const SpeechRecognitionImpl = getSpeechRecognition();
+    if (!active || !SpeechRecognitionImpl) return;
+
+    const recognition = new SpeechRecognitionImpl();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = "en-US";
+
+    let stopped = false;
+
+    recognition.onresult = (event) => {
+      const results = Array.from(
+        { length: event.results.length },
+        (_, i) => event.results[i],
+      );
+      const text = results
+        .map((result) => result?.[0]?.transcript ?? "")
+        .join(" ")
+        .trim();
+      setTranscript(text);
+
+      const r = matchRatio(text, targetRef.current);
+      setRatio(r);
+      if (r >= threshold && !matchedRef.current) {
+        matchedRef.current = true;
+        onMatchRef.current();
+      }
+    };
+
+    recognition.onerror = (event) => {
+      // "no-speech" just ends the session and onend restarts it, but a
+      // permission denial must not trigger the restart loop
+      if (
+        event.error === "not-allowed" ||
+        event.error === "service-not-allowed" ||
+        event.error === "audio-capture"
+      ) {
+        stopped = true;
+        setListening(false);
+      }
+    };
+
+    // Recognition sessions time out on silence — restart while still active
+    recognition.onend = () => {
+      if (!stopped) {
+        try {
+          recognition.start();
+        } catch {
+          setListening(false);
+        }
+      }
+    };
+
+    try {
+      recognition.start();
+      setListening(true);
+      recognitionRef.current = recognition;
+    } catch {
+      setListening(false);
+    }
+
+    return () => {
+      stopped = true;
+      recognition.onresult = null;
+      recognition.onend = null;
+      try {
+        recognition.abort();
+      } catch {
+        // already stopped
+      }
+      recognitionRef.current = null;
+      setListening(false);
+      setTranscript("");
+      setRatio(0);
+    };
+  }, [active, threshold]);
+
+  const stop = useCallback(() => {
+    recognitionRef.current?.abort();
+  }, []);
+
+  return { supported, listening, transcript, ratio, stop };
+}

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -2,6 +2,7 @@ import { postRouter } from "~/server/api/routers/post";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 import { scriptData } from "./routers/scriptData";
 import { firebaseRouter } from "./routers/firebase";
+import { voiceRouter } from "./routers/voice";
 
 /**
  * This is the primary router for your server.
@@ -12,6 +13,7 @@ export const appRouter = createTRPCRouter({
   post: postRouter,
   scriptData: scriptData,
   firebase: firebaseRouter,
+  voice: voiceRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/voice.ts
+++ b/src/server/api/routers/voice.ts
@@ -1,0 +1,81 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
+import { adminDb } from "~/lib/firebase-admin";
+
+/**
+ * Scene-partner voice (TTS) — STUB, not live yet.
+ *
+ * The plan: generate audio for the *other* characters' lines with a TTS
+ * provider, and cache every generated clip forever so each unique line is
+ * paid for exactly once.
+ *
+ * Cache design:
+ * - Key: sha256(voiceId + "::" + normalized line text). Script lines rarely
+ *   change, so repeat practice sessions are 100% cache hits.
+ * - Index: Firestore collection `voiceClips`, doc id = key, fields:
+ *   { voiceId, text, storagePath, createdAt, byUser }
+ * - Audio bytes: Firebase Storage at `voiceClips/{key}.mp3`, served via a
+ *   long-lived download URL stored on the doc.
+ *
+ * To go live:
+ * 1. Pick a provider (OpenAI `tts-1` or ElevenLabs; both ~ $0.015/1k chars —
+ *    a full scene is pennies, and the cache makes reruns free).
+ * 2. Add the API key to env.js + .env (e.g. OPENAI_API_KEY), and flip
+ *    VOICE_GENERATION_ENABLED=true.
+ * 3. Implement generateClip() below: call the provider, upload the bytes to
+ *    Firebase Storage, write the `voiceClips` doc, return the URL.
+ * 4. Client: a usePartnerVoice hook that prefetches the next few other-
+ *    character lines when a scene starts, and plays each clip as its line
+ *    is revealed. Wire the "Scene Partner Voice" sidebar toggle to it.
+ */
+
+const VOICE_CLIPS_COLLECTION = "voiceClips";
+const DEFAULT_VOICE_ID = "default";
+
+const generationEnabled = () =>
+  process.env.VOICE_GENERATION_ENABLED === "true";
+
+/** Deterministic cache key: one clip per unique (voice, line) pair */
+export const clipKey = (voiceId: string, text: string): string =>
+  createHash("sha256")
+    .update(`${voiceId}::${text.trim().toLowerCase()}`)
+    .digest("hex");
+
+export const voiceRouter = createTRPCRouter({
+  /**
+   * Look up (or eventually generate) the audio clip for one line.
+   * While generation is disabled this only ever reports cache status,
+   * so it is safe to call from the client today.
+   */
+  getLineAudio: protectedProcedure
+    .input(
+      z.object({
+        text: z.string().min(1).max(2000),
+        voiceId: z.string().default(DEFAULT_VOICE_ID),
+      }),
+    )
+    .query(async ({ input }) => {
+      const key = clipKey(input.voiceId, input.text);
+
+      const doc = await adminDb
+        .collection(VOICE_CLIPS_COLLECTION)
+        .doc(key)
+        .get();
+
+      if (doc.exists) {
+        const data = doc.data() as { url?: string };
+        if (data.url) {
+          return { status: "cached" as const, key, url: data.url };
+        }
+      }
+
+      if (!generationEnabled()) {
+        // TODO(voice): call generateClip(input) here once a TTS provider is
+        // wired up and VOICE_GENERATION_ENABLED is set.
+        return { status: "unavailable" as const, key, url: null };
+      }
+
+      return { status: "pending" as const, key, url: null };
+    }),
+});


### PR DESCRIPTION
> Stacked on #48.

## Summary

**Speech Match (live)**
- New `useSpeechMatch` hook wrapping the Web Speech API (Chrome/Safari), with auto-restart on silence timeouts and a guard against permission-denial restart loops
- Scoring: longest-common-subsequence over normalized words — case/punctuation/apostrophe-insensitive, tolerant of filler words and recognizer noise, strict about word order; ≥ 80% of the line counts as a match (unit-tested against 8 cases)
- With the sidebar **Speech Match** toggle on: when the current line is yours, the runner listens, shows a mic strip with live transcript and match progress, reveals the line when you've said it, and advances after a beat
- Preference persists to localStorage (read after mount — no hydration mismatch)

**Scene Partner Voice (stub — intentionally not live)**
- `voice` tRPC router with `getLineAudio`: checks a Firestore `voiceClips` cache keyed by `sha256(voiceId + text)`, so each unique line is ever generated once — repeat practice is free
- Generation is gated behind `VOICE_GENERATION_ENABLED` and not implemented; the router docblock spells out the go-live steps (provider choice, storage upload, client playback hook)
- Sidebar shows a disabled "Scene Partner Voice — coming soon" toggle

## Test plan
- [x] `npm run build`, `npm run lint`, `tsc --noEmit` pass
- [x] Match scoring verified against 8 unit cases (exact / no-punct / filler / recognizer variant / partial / wrong line / out-of-order / empty)
- [x] Verified in browser: toggle renders and persists, mic strip appears on the user's line only, no console errors
- [ ] Real-mic end-to-end check in Chrome (say a line, watch it advance) — needs a human with a microphone 🎤

🤖 Generated with [Claude Code](https://claude.com/claude-code)