### PR TITLE
Fix speaker attribution for character names not in the supplied list

### DIFF
--- a/src/components/AddScriptDoc.tsx
+++ b/src/components/AddScriptDoc.tsx
@@ -300,15 +300,6 @@ export const AddScriptDoc = () => {
       return;
     }
 
-    if (scriptCharacterNames.length === 0) {
-      toast({
-        title: "Error",
-        description: "Please enter character names",
-        variant: "destructive",
-      });
-      return;
-    }
-
     if (!script.trim()) {
       toast({
         title: "Error",
@@ -389,29 +380,69 @@ export const AddScriptDoc = () => {
     }
   };
 
+  // Character names come from the user, but scripts routinely contain speakers
+  // the user did not list. A standalone upper-case line that looks like a name
+  // ("CINDERELLA", "CP/RP") is treated as a speaker header and registered on
+  // the fly, so an incomplete list no longer swallows a whole character.
   const parseScript = (script: string, characterNames: string[]) => {
-    console.log("=== PARSING DEBUG ===");
-    console.log("Input script:", JSON.stringify(script));
-    console.log("Character names:", characterNames);
-
     const lines = script.split(/\n/);
-    console.log("Split lines:", lines.map(line => `"${line}"`));
     const parsedLines: { characters: string[]; line: string; sung?: boolean }[] =
       [];
-    let currentCharacter = "";
+    const knownCharacters = [...characterNames];
+    let currentCharacters: string[] = [];
     let currentLine = "";
+
+    const multiCharSeparators = /\s*[&\/,]\s*/;
 
     // Helper function to normalize text by removing spaces
     const normalizeText = (text: string) =>
       text.toLowerCase().replace(/\s+/g, "");
 
-    // Helper function to check if a line is sung (all caps)
-    const isSungLine = (text: string) => {
-      // Remove spaces and punctuation, check if all remaining characters are uppercase
+    // Remove punctuation, then check whether what remains is all upper-case
+    const isAllCaps = (text: string) => {
       const cleanedText = text.replace(/[^a-zA-Z]/g, "");
       return (
         cleanedText.length > 0 && cleanedText === cleanedText.toUpperCase()
       );
+    };
+
+    // Helper function to check if a line is sung (all caps)
+    const isSungLine = (text: string) => isAllCaps(text);
+
+    // Sung lyrics are upper-case too, so shape is what separates them: a
+    // speaker header is short and never ends in sentence punctuation.
+    const looksLikeCharacterHeader = (text: string) => {
+      const core = text.replace(/:\s*$/, "").trim();
+      if (!core || !isAllCaps(core)) return false;
+      if (/[.,!?;…-]$/.test(core)) return false;
+      return core.split(/\s+/).length <= 3;
+    };
+
+    // Resolve a header to canonical character names, registering unseen ones
+    const resolveHeaderCharacters = (header: string) => {
+      const core = header.replace(/:\s*$/, "").trim();
+      return core
+        .split(multiCharSeparators)
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0)
+        .map((part) => {
+          const known = knownCharacters.find(
+            (name) => normalizeText(name) === normalizeText(part),
+          );
+          if (known) return known;
+          knownCharacters.push(part);
+          return part;
+        });
+    };
+
+    const flushCurrentLine = () => {
+      if (currentCharacters.length > 0 && currentLine.trim()) {
+        parsedLines.push({
+          characters: [...currentCharacters],
+          line: currentLine.trim(),
+        });
+      }
+      currentLine = "";
     };
 
     for (const line of lines) {
@@ -419,194 +450,118 @@ export const AddScriptDoc = () => {
       if (!trimmedLine) continue; // Skip empty lines
 
       // Check for multiple character:line patterns within a single line
-      // Create a regex that matches CHARACTER: pattern for any of the provided character names
-      const characterPattern = new RegExp(
-        `\\b(${characterNames.map(name => name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})\\s*:`,
-        'gi'
-      );
-      
-      const matches = [...trimmedLine.matchAll(characterPattern)];
-      console.log(`Found ${matches.length} character matches:`, matches.map(m => ({ match: m[0], character: m[1], index: m.index })));
-      
+      const characterPattern =
+        knownCharacters.length > 0
+          ? new RegExp(
+              `\\b(${knownCharacters
+                .map((name) => name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+                .join("|")})\\s*:`,
+              "gi",
+            )
+          : null;
+
+      const matches = characterPattern
+        ? [...trimmedLine.matchAll(characterPattern)]
+        : [];
+
       if (matches.length > 1) {
-        console.log("Processing multiple character patterns in line");
         // Multiple character patterns found in this line - split them up
+        flushCurrentLine();
         for (let i = 0; i < matches.length; i++) {
           const match = matches[i];
           if (!match) continue;
 
           const nextMatch = matches[i + 1];
-
           const characterName = match[1];
           if (!characterName) continue;
 
           const startIndex = (match.index ?? 0) + match[0].length;
-          const endIndex = nextMatch ? (nextMatch.index ?? 0) : trimmedLine.length;
-
+          const endIndex = nextMatch
+            ? (nextMatch.index ?? 0)
+            : trimmedLine.length;
           const dialogue = trimmedLine.substring(startIndex, endIndex).trim();
 
-          // Find the proper case version of the character name
-          const foundCharacter = characterNames.find((name) => {
-            const normalizedName = normalizeText(name);
-            const normalizedMatch = normalizeText(characterName);
-            return normalizedName === normalizedMatch;
-          });
+          const foundCharacter = knownCharacters.find(
+            (name) => normalizeText(name) === normalizeText(characterName),
+          );
 
           if (foundCharacter && dialogue) {
-            console.log(`  Adding character line: ${foundCharacter} - "${dialogue}"`);
             const isSung = isSungLine(dialogue);
             parsedLines.push({
               characters: [foundCharacter],
               line: dialogue,
               ...(isSung && { sung: true }),
             });
-          } else {
-            console.log(`  Skipped - foundCharacter: ${foundCharacter}, dialogue: "${dialogue}"`);
+            currentCharacters = [foundCharacter];
           }
         }
         continue;
       }
 
-      // Check for character:line format first
-      const colonIndex = trimmedLine.indexOf(':');
+      // Check for "CHARACTER: line" format, including "CHAR1/CHAR2: line"
+      const colonIndex = trimmedLine.indexOf(":");
       if (colonIndex > 0) {
         const potentialCharacter = trimmedLine.substring(0, colonIndex).trim();
         const potentialLine = trimmedLine.substring(colonIndex + 1).trim();
 
-        // Check for multi-character format: "CHARACTER1 & CHARACTER2:" or "CHARACTER1/CHARACTER2:" or "CHARACTER1, CHARACTER2:"
-        const multiCharSeparators = /\s*[&\/,]\s*/;
-        if (multiCharSeparators.test(potentialCharacter)) {
-          const potentialCharacters = potentialCharacter.split(multiCharSeparators).map(c => c.trim()).filter(c => c.length > 0);
+        if (potentialLine) {
+          const potentialCharacters = potentialCharacter
+            .split(multiCharSeparators)
+            .map((c) => c.trim())
+            .filter((c) => c.length > 0);
 
-          // Validate all parts are known character names
-          const foundCharacters = potentialCharacters.map(pc =>
-            characterNames.find(name => normalizeText(name) === normalizeText(pc))
-          ).filter((c): c is string => c !== undefined);
+          const allKnown =
+            potentialCharacters.length > 0 &&
+            potentialCharacters.every((pc) =>
+              knownCharacters.some(
+                (name) => normalizeText(name) === normalizeText(pc),
+              ),
+            );
 
-          // If all parts matched character names, create a multi-character line
-          if (foundCharacters.length === potentialCharacters.length && foundCharacters.length > 0 && potentialLine) {
-            // If we have a previous character and line, save it first
-            if (currentCharacter && currentLine.trim()) {
-              parsedLines.push({
-                characters: [currentCharacter],
-                line: currentLine.trim(),
-              });
-            }
-
-            // Add the multi-character line
+          if (allKnown || looksLikeCharacterHeader(potentialCharacter)) {
+            flushCurrentLine();
+            const resolved = resolveHeaderCharacters(potentialCharacter);
             const isSung = isSungLine(potentialLine);
             parsedLines.push({
-              characters: foundCharacters,
+              characters: resolved,
               line: potentialLine,
               ...(isSung && { sung: true }),
             });
-
-            currentCharacter = foundCharacters[0] ?? "";
-            currentLine = "";
+            currentCharacters = resolved;
             continue;
           }
         }
-
-        // Check if the part before the colon matches any single character name
-        const foundCharacter = characterNames.find((name) => {
-          const normalizedName = normalizeText(name);
-          const normalizedPotentialCharacter = normalizeText(potentialCharacter);
-          return normalizedName === normalizedPotentialCharacter;
-        });
-
-        if (foundCharacter && potentialLine) {
-          // If we have a previous character and line, save it first
-          if (currentCharacter && currentLine.trim()) {
-            parsedLines.push({
-              characters: [currentCharacter],
-              line: currentLine.trim(),
-            });
-          }
-
-          // Add the new character line
-          const isSung = isSungLine(potentialLine);
-          parsedLines.push({
-            characters: [foundCharacter],
-            line: potentialLine,
-            ...(isSung && { sung: true }),
-          });
-
-          currentCharacter = foundCharacter;
-          currentLine = "";
-          continue;
-        }
       }
 
-      // First check if this is a sung line (all caps) - but exclude simple character names
-      const isCharacterNameOnly = characterNames.some((name) => {
-        const normalizedName = normalizeText(name);
-        const normalizedLine = normalizeText(trimmedLine);
-        return (
-          normalizedLine === normalizedName ||
-          normalizedLine === normalizedName + ":" ||
-          normalizedLine.replace(/[^a-z]/g, "") === normalizedName
-        );
-      });
+      // A standalone name line ("CINDERELLA", "CP/RP") opens that speaker's lines
+      if (looksLikeCharacterHeader(trimmedLine)) {
+        flushCurrentLine();
+        currentCharacters = resolveHeaderCharacters(trimmedLine);
+        continue;
+      }
 
-      if (!isCharacterNameOnly && isSungLine(trimmedLine)) {
-        // If we have a previous character and line, save it first
-        if (currentCharacter && currentLine.trim()) {
+      // Upper-case, but not a speaker header, so it is a sung lyric
+      if (isSungLine(trimmedLine)) {
+        flushCurrentLine();
+        if (currentCharacters.length > 0) {
           parsedLines.push({
-            characters: [currentCharacter],
-            line: currentLine.trim(),
-          });
-        }
-        // Add the sung line as a separate line object
-        if (currentCharacter) {
-          parsedLines.push({
-            characters: [currentCharacter],
+            characters: [...currentCharacters],
             line: trimmedLine,
             sung: true,
           });
         }
-        currentLine = "";
-      } else {
-        // Check if this line is a character name (should be at the start of the line)
-        const foundCharacter = characterNames.find((name) => {
-          const normalizedName = normalizeText(name);
-          const normalizedLine = normalizeText(trimmedLine);
-          // Check if line starts with character name or is exactly the character name
-          return (
-            normalizedLine === normalizedName ||
-            normalizedLine.startsWith(normalizedName + ":") ||
-            normalizedLine.startsWith(normalizedName + " ")
-          );
-        });
+        continue;
+      }
 
-        if (foundCharacter) {
-          // If we have a previous character and line, save it
-          if (currentCharacter && currentLine.trim()) {
-            parsedLines.push({
-              characters: [currentCharacter],
-              line: currentLine.trim(),
-            });
-          }
-          // Start new character
-          currentCharacter = foundCharacter;
-          currentLine = "";
-        } else {
-          // This line is regular dialogue for the current character
-          if (currentCharacter) {
-            currentLine += (currentLine ? " " : "") + trimmedLine;
-          }
-        }
+      // Regular dialogue for the current speaker
+      if (currentCharacters.length > 0) {
+        currentLine += (currentLine ? " " : "") + trimmedLine;
       }
     }
 
     // Save the last lines
-    if (currentCharacter && currentLine.trim()) {
-      parsedLines.push({
-        characters: [currentCharacter],
-        line: currentLine.trim(),
-      });
-    }
+    flushCurrentLine();
 
-    console.log("Final parsed result:", parsedLines);
     return parsedLines;
   };
 

--- a/src/server/scriptService.ts
+++ b/src/server/scriptService.ts
@@ -19,33 +19,85 @@ export interface SceneJSON {
   lines: LineJSON[];
 }
 
+// Shapes accepted on read, before normalization to LineJSON/ProjectJSON
+export interface RawLine {
+  characters?: unknown;
+  character?: unknown;
+  line?: unknown;
+  sung?: boolean;
+}
+
+export interface RawScene {
+  title?: unknown;
+  lines?: RawLine[];
+}
+
+export interface RawProject {
+  project?: unknown;
+  scenes?: RawScene[];
+  characters?: unknown;
+}
+
 export interface GetAllResponse {
   projects: string[];
   allData: ProjectJSON[];
 }
 
 export class ScriptService {
+  // Scripts on disk and in Firestore predate the current schema: older lines
+  // store a single `character: string`, and some files hold an array of
+  // projects rather than one. Normalize both on read so a legacy document
+  // cannot take down the whole data source.
+  static normalizeLine(line: RawLine): LineJSON {
+    const characters = Array.isArray(line?.characters)
+      ? line.characters.filter((c): c is string => typeof c === "string")
+      : typeof line?.character === "string" && line.character
+        ? [line.character]
+        : [];
+
+    return {
+      characters,
+      line: typeof line?.line === "string" ? line.line : "",
+      ...(line?.sung ? { sung: true } : {}),
+    };
+  }
+
+  static normalizeProject(project: RawProject): ProjectJSON {
+    const rawScenes = Array.isArray(project?.scenes) ? project.scenes : [];
+    const scenes: SceneJSON[] = rawScenes.map((scene) => ({
+      title: typeof scene?.title === "string" ? scene.title : "",
+      lines: Array.isArray(scene?.lines)
+        ? scene.lines.map((line) => this.normalizeLine(line))
+        : [],
+    }));
+
+    const declared = Array.isArray(project?.characters)
+      ? project.characters.filter((c): c is string => typeof c === "string")
+      : [];
+
+    return {
+      project: typeof project?.project === "string" ? project.project : "",
+      scenes,
+      characters:
+        declared.length > 0 ? declared : this.generateCharactersFromScenes(scenes),
+    };
+  }
+
   // Helper function to generate characters array from scenes
   static generateCharactersFromScenes(scenes: SceneJSON[]): string[] {
     const charactersSet = new Set<string>();
-    scenes.forEach(scene => {
-      scene.lines.forEach(line => {
+    (scenes ?? []).forEach((scene) => {
+      (scene?.lines ?? []).forEach((line) => {
         // Use characters array (new schema)
-        line.characters.forEach(char => charactersSet.add(char));
+        (line?.characters ?? []).forEach((char) => charactersSet.add(char));
       });
     });
     return Array.from(charactersSet).sort();
   }
 
   // Helper function to ensure project has characters array
-  static ensureCharactersArray(project: ProjectJSON): ProjectJSON {
-    if (!project.characters) {
-      return {
-        ...project,
-        characters: this.generateCharactersFromScenes(project.scenes)
-      };
-    }
-    return project;
+  static ensureCharactersArray(project: RawProject): ProjectJSON {
+    return this.normalizeProject(project);
   }
 
   // Load scripts from local files
@@ -53,10 +105,13 @@ export class ScriptService {
     const directory = path.join(process.cwd(), "public/sceneData");
     const files = fs.readdirSync(directory);
     const allData: ProjectJSON[] = files
+      .filter((file) => file.endsWith(".json"))
       .map((file) => {
         const data = fs.readFileSync(path.join(directory, file), "utf8");
-        const project = JSON.parse(data) as ProjectJSON;
-        return this.ensureCharactersArray(project);
+        // A file may hold a single project or an array of them
+        const parsed = JSON.parse(data) as RawProject | RawProject[];
+        const projects = Array.isArray(parsed) ? parsed : [parsed];
+        return projects.map((project) => this.normalizeProject(project));
       })
       .flat();
 


### PR DESCRIPTION
## The bug

A screenplay-formatted script parsed into nonsense: every line attributed to one character, with the other character's name rendered as dialogue.

```
 1 | CP: Hello.
 2 | CP: CINDERELLA                        <- should start Cinderella's line
 3 | CP: The Giant went in that direction. <- Cinderella's line, credited to CP
```

## Root cause

`parseScript` only accepted a line as a speaker header if the name was in the user-entered character list. For an unlisted name like `CINDERELLA`:

1. it wasn't recognised as a header, so
2. it fell to the sung-line branch — and since character names are upper-case, `isSungLine` matched, so
3. it was emitted as a **sung lyric belonging to the previous speaker**, and that speaker's real dialogue was folded into the wrong lines.

Anything before the first *listed* character was dropped outright, which is why the scene's opening line was missing.

## The fix

Speaker headers are now detected structurally — a short upper-case line that doesn't end in sentence punctuation — which is what separates `CINDERELLA` from a lyric like `INTO THE WOODS,`. Unseen names are registered on the fly, so an incomplete character list no longer swallows a character.

Validated against a 1091-line script: the heuristic finds **all 34 distinct headers** (including `CP/RP` and `BAKER/BAKER'S WIFE/JACK/CINDERELLA`), misclassifies **no lyrics**, and misses **no headers**. Parsing that script with an *empty* character list recovers all 21 characters, with sung lyrics still flagged and attributed correctly.

Also: the current speaker is now tracked as a list so bare multi-character headers behave like `CHAR1/CHAR2:` already did; the character-names field is no longer required on submit; and the per-line `console.log` tracing is gone.

## Second, unrelated crash

`ScriptService.generateCharactersFromScenes` assumed every line had a `characters` array. Legacy documents store a single `character` string, and some scene files hold an array of projects rather than one — reading either threw `Cannot read properties of undefined (reading 'forEach')` and took down **the entire data source**, not just the offending document. On `main` this makes the `local` source return a 500. Both shapes are now normalized on read.

## Verification

Ran the app locally and drove it with [agent-browser](https://github.com/vercel-labs/agent-browser). Speakers alternate correctly and the dropped opening line is back:

```
 1 | CINDERELLA: Oh, no. Now, now. Don't cry, little one...
 2 | CP: Hello.
 3 | CINDERELLA: The Giant went in that direction.
 4 | CP: My darling. I did not recognize you...
```

`tsc --noEmit` clean; `npm run lint` 0 errors (10 pre-existing warnings).

## Note

This fixes **parsing**, so it applies to newly imported scripts. The already-stored "Into the Woods" document in Firestore still holds the corrupted lines and needs re-importing to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)