### PR TITLE
Keep libretto source text out of the repo

### DIFF
--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,2 +1,6 @@
 # Backup files contain user data and should not be committed
 backups/
+
+# Show/libretto source text is copyrighted — keep it local
+*.md
+!README.md


### PR DESCRIPTION
`scripts/` is where show text gets staged before import, and this repo is public. The directory already excludes `backups/` for containing user data — copyrighted script text belongs in the same category.

Without this, `scripts/ittw-scripts.md` (the Into the Woods libretto, currently sitting untracked in the working tree) would be swept up by any `git add -A`.

`README.md` stays tracked so the directory can still document itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)